### PR TITLE
Fix/reset tmp storage after s3 error

### DIFF
--- a/edu_edfi_airflow/providers/edfi/transfers/edfi_to_s3.py
+++ b/edu_edfi_airflow/providers/edfi/transfers/edfi_to_s3.py
@@ -153,16 +153,18 @@ class EdFiToS3Operator(BaseOperator):
         s3_hook = S3Hook(aws_conn_id=self.s3_conn_id)
         s3_bucket = s3_hook.get_connection(self.s3_conn_id).schema
 
-        s3_hook.load_file(
-            filename=tmp_file,
+        try:
+            s3_hook.load_file(
+                filename=tmp_file,
 
-            bucket_name=s3_bucket,
-            key=self.s3_destination_key,
+                bucket_name=s3_bucket,
+                key=self.s3_destination_key,
 
-            encrypt=True,
-            replace=True
-        )
-        self.delete_path(tmp_file)
+                encrypt=True,
+                replace=True
+            )
+        finally:
+            self.delete_path(tmp_file)
 
         return self.s3_destination_key
 

--- a/edu_edfi_airflow/providers/edfi/transfers/edfi_to_s3.py
+++ b/edu_edfi_airflow/providers/edfi/transfers/edfi_to_s3.py
@@ -150,10 +150,10 @@ class EdFiToS3Operator(BaseOperator):
             raise AirflowSkipException
 
         ### Connect to S3 and push
-        s3_hook = S3Hook(aws_conn_id=self.s3_conn_id)
-        s3_bucket = s3_hook.get_connection(self.s3_conn_id).schema
-
         try:
+            s3_hook = S3Hook(aws_conn_id=self.s3_conn_id)
+            s3_bucket = s3_hook.get_connection(self.s3_conn_id).schema
+
             s3_hook.load_file(
                 filename=tmp_file,
 


### PR DESCRIPTION
This branch adds a try-finally block around the S3 import in EdFiToS3Operator. If an S3 permissions error is encountered, the local Ed-Fi data is still deleted before an error is raised.