### PR TITLE
Comment-out endpoint-ping.

### DIFF
--- a/edu_edfi_airflow/providers/edfi/transfers/edfi_to_s3.py
+++ b/edu_edfi_airflow/providers/edfi/transfers/edfi_to_s3.py
@@ -96,10 +96,10 @@ class EdFiToS3Operator(BaseOperator):
             min_change_version=self.min_change_version, max_change_version=self.max_change_version
         )
 
-        # Fail immediately if the endpoint is forbidden.
-        _response = resource_endpoint.ping()
-        if not _response.ok:
-            raise Exception(f"Unable to connect to `{self.resource}`! {_response.status_code}: {_response.reason}")
+        # # Fail immediately if the endpoint is forbidden.
+        # _response = resource_endpoint.ping()
+        # if not _response.ok:
+        #     raise Exception(f"Unable to connect to `{self.resource}`! {_response.status_code}: {_response.reason}")
 
         # Iterate the ODS, paginating across offset and change version steps.
         # Write each result to the temp file.


### PR DESCRIPTION
When running a simple GET request, regardless of limit, the ODS behind the scenes runs an order-by against all(?) columns. This means that the current `ping()` implementation is likely to time-out on high-volume resources.

There are a couple solutions to this (involving setting parameters in the GET-request that are less intensive behind the scenes), but for now I'm simply commenting-out this check and letting it fail during first ingest instead.

