### PR TITLE
Add query_parameters to resource definition.

### DIFF
--- a/edu_edfi_airflow/providers/edfi/transfers/edfi_to_s3.py
+++ b/edu_edfi_airflow/providers/edfi/transfers/edfi_to_s3.py
@@ -92,7 +92,7 @@ class EdFiToS3Operator(BaseOperator):
 
         # Prepare the EdFiEndpoint for the resource.
         resource_endpoint = edfi_conn.resource(
-            self.resource, namespace=self.api_namespace, get_deletes=self.api_get_deletes,
+            self.resource, namespace=self.api_namespace, get_deletes=self.api_get_deletes, params=self.query_parameters,
             min_change_version=self.min_change_version, max_change_version=self.max_change_version
         )
 


### PR DESCRIPTION
The `query_parameters` argument was missed in the `EdFiResource` declaration in `EdFiToS3Operator`. This resulted in the entire ODS being ingested in multiyear runs, instead of the specific year only. Once tested in our multiyear Stadium implementation, we can merge this into main.