### PR TITLE
Turn off reverse_paging for deletes ingestion.

### DIFF
--- a/edu_edfi_airflow/providers/edfi/transfers/edfi_to_s3.py
+++ b/edu_edfi_airflow/providers/edfi/transfers/edfi_to_s3.py
@@ -113,6 +113,7 @@ class EdFiToS3Operator(BaseOperator):
             paged_iter = resource_endpoint.get_pages(
                 page_size=self.page_size,
                 step_change_version=step_change_version, change_version_step_size=self.change_version_step_size,
+                reverse_paging=(not self.api_get_deletes),  # Reverse_paging is true for resources and false for deletes
                 retry_on_failure=True, max_retries=self.api_retries
             )
 


### PR DESCRIPTION
Not all Ed-Fi ODS implementations permit total-counts to be pulled from deletes endpoints. Additionally, it's unlikely that deletes endpoints change in the same manner as resource endpoints, so reverse pagination should not be necessary on these endpoints. This PR sets `reverse_paging` on deletes to false.

Note, `feature/reverse_paging` must be merged in `edfi_api_client` before this PR is merged.