### PR TITLE
Feature/refactor change version post copy

### DIFF
--- a/edu_edfi_airflow/dags/callables/change_version.py
+++ b/edu_edfi_airflow/dags/callables/change_version.py
@@ -189,11 +189,11 @@ def update_change_versions(
 
     for task_id in kwargs['task'].get_direct_relative_ids(upstream=True):
 
-        xcom_result = airflow_util.xcom_pull_template(task_id)
+        xcom_result = kwargs['ti'].xcom_pull(task_id)
         logging.info(f"{task_id}: {xcom_result}")
 
         # Only log successful copies into Snowflake (skips will return None)
-        if not airflow_util.xcom_pull_template(task_id):
+        if not xcom_result:
             continue
 
         # Extract resource name and deletes flag from task_id.

--- a/edu_edfi_airflow/dags/callables/change_version.py
+++ b/edu_edfi_airflow/dags/callables/change_version.py
@@ -187,7 +187,11 @@ def update_change_versions(
     """
     rows_to_insert = []
 
-    for task_id in kwargs['ti'].get_direct_relative_ids(upstream=True):
+    # for task_id in kwargs['task'].get_direct_relative_ids(upstream=True):
+    for task_id in kwargs['task'].upstream_task_ids:
+
+        xcom_result = airflow_util.xcom_pull_template(task_id)
+        logging.info(task_id, xcom_result)
 
         # Only log successful copies into Snowflake (skips will return None)
         if not airflow_util.xcom_pull_template(task_id):

--- a/edu_edfi_airflow/dags/callables/change_version.py
+++ b/edu_edfi_airflow/dags/callables/change_version.py
@@ -124,51 +124,6 @@ def get_previous_change_versions(
         kwargs['ti'].xcom_push(key=xcom_key, value=max_version)
 
 
-# def update_resource_change_version(
-#     tenant_code: str,
-#     api_year   : int,
-#     resource   : str,
-#     deletes    : str,
-#
-#     snowflake_conn_id: str,
-#     change_version_table: str,
-#
-#     edfi_change_version: int,
-#
-#     **kwargs
-# ):
-#     """
-#
-#     :return:
-#     """
-#     # Retrieve the database and schema from the Snowflake hook.
-#     database, schema = airflow_util.get_snowflake_params_from_conn(snowflake_conn_id)
-#
-#     # Build the SQL queries to be passed into `Hook.run()`.
-#     qry_insert_into = f"""
-#         insert into {database}.{schema}.{change_version_table}
-#             (tenant_code, api_year, name, is_deletes, pull_date, pull_timestamp, max_version, is_active)
-#         select
-#             '{tenant_code}',
-#             '{api_year}',
-#             '{resource}',
-#             {deletes},
-#             to_date('{kwargs["ds_nodash"]}', 'YYYYMMDD'),
-#             to_timestamp('{kwargs["ts_nodash"]}', 'YYYYMMDDTHH24MISS'),
-#             {edfi_change_version},
-#             TRUE
-#         ;
-#     """
-#
-#     snowflake_hook = SnowflakeHook(snowflake_conn_id=snowflake_conn_id)
-#
-#     cursor_log = snowflake_hook.run(
-#         sql=qry_insert_into
-#     )
-#
-#     logging.info(cursor_log)
-
-
 def update_change_versions(
     tenant_code: str,
     api_year   : int,
@@ -189,11 +144,8 @@ def update_change_versions(
 
     for task_id in kwargs['task'].get_direct_relative_ids(upstream=True):
 
-        xcom_result = kwargs['ti'].xcom_pull(task_id)
-        logging.info(f"{task_id}: {xcom_result}")
-
         # Only log successful copies into Snowflake (skips will return None)
-        if not xcom_result:
+        if not kwargs['ti'].xcom_pull(task_id):
             continue
 
         # Extract resource name and deletes flag from task_id.

--- a/edu_edfi_airflow/dags/callables/change_version.py
+++ b/edu_edfi_airflow/dags/callables/change_version.py
@@ -187,11 +187,10 @@ def update_change_versions(
     """
     rows_to_insert = []
 
-    # for task_id in kwargs['task'].get_direct_relative_ids(upstream=True):
-    for task_id in kwargs['task'].upstream_task_ids:
+    for task_id in kwargs['task'].get_direct_relative_ids(upstream=True):
 
         xcom_result = airflow_util.xcom_pull_template(task_id)
-        logging.info(task_id, xcom_result)
+        logging.info(f"{task_id}: {xcom_result}")
 
         # Only log successful copies into Snowflake (skips will return None)
         if not airflow_util.xcom_pull_template(task_id):

--- a/edu_edfi_airflow/dags/callables/change_version.py
+++ b/edu_edfi_airflow/dags/callables/change_version.py
@@ -161,9 +161,14 @@ def update_change_versions(
             )"""
         )
 
-    logging.info(
-        f"Collected updated change versions for {len(rows_to_insert)} endpoints."
-    )
+    if not rows_to_insert:
+        raise AirflowSkipException(
+            "There are no new change versions to update for any endpoints. All upstream tasks skipped or failed."
+        )
+    else:
+        logging.info(
+            f"Collected updated change versions for {len(rows_to_insert)} endpoints."
+        )
 
     # Retrieve the database and schema from the Snowflake hook.
     database, schema = airflow_util.get_snowflake_params_from_conn(snowflake_conn_id)

--- a/edu_edfi_airflow/dags/callables/change_version.py
+++ b/edu_edfi_airflow/dags/callables/change_version.py
@@ -187,7 +187,7 @@ def update_change_versions(
     """
     rows_to_insert = []
 
-    for task_id in kwargs['task'].get_direct_relative_ids(upstream=True):
+    for task_id in kwargs['ti'].get_direct_relative_ids(upstream=True):
 
         # Only log successful copies into Snowflake (skips will return None)
         if not airflow_util.xcom_pull_template(task_id):

--- a/edu_edfi_airflow/dags/dag_util/airflow_util.py
+++ b/edu_edfi_airflow/dags/dag_util/airflow_util.py
@@ -8,15 +8,21 @@ from edfi_api_client import camel_to_snake
 def build_display_name(resource: str, is_deletes: bool = False) -> str:
     """
     Universal helper method for building the display name of a resource.
-
-    :param resource:
-    :param is_deletes:
-    :return:
     """
     if is_deletes:
         return f"{resource}_deletes"
     else:
         return resource
+
+def split_display_name(display_name: str) -> (str, bool):
+    """
+    Universal helper method for splitting the display name of a resource into resource and deletes flag.
+    """
+    if display_name.endswith("_deletes"):
+        resource = display_name.replace("_deletes", "")
+        return resource, True
+    else:
+        return display_name, False
 
 
 def is_full_refresh(context) -> bool:

--- a/edu_edfi_airflow/providers/snowflake/transfers/s3_to_snowflake.py
+++ b/edu_edfi_airflow/providers/snowflake/transfers/s3_to_snowflake.py
@@ -109,3 +109,4 @@ class S3ToSnowflakeOperator(BaseOperator):
             )
 
         logging.info(cursor_log)
+        return True  # Return for update_change_versions() xcom pull


### PR DESCRIPTION
This PR builds off of feature/refactor_change_version (PR #8). It uses xcoms to collect a list of successful copies into Snowflake and updates the meta-change-version table with a single insert statement. This should improve run-time performance even more, as it strips out up to another ~200 tasks from each run.