### PR TITLE
Refactor task-group ordering to branch EM/LB logging outside of main …

### DIFF
--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -371,7 +371,7 @@ class EarthbeamDAG:
                     dag=self.dag
                 )
 
-                task_order.append(log_earthmover_to_snowflake)
+                run_earthmover >> log_earthmover_to_snowflake
 
 
             ### Earthmover to S3
@@ -458,7 +458,7 @@ class EarthbeamDAG:
                         dag=self.dag
                     )
 
-                    task_order.append(log_lightbeam_to_snowflake)
+                    run_lightbeam >> log_lightbeam_to_snowflake
 
 
             ### Alternate route: Bypassing the ODS directly into Snowflake


### PR DESCRIPTION
…task group.

Because the logging tasks use "all_done" trigger rules, when one re-runs a failed task in the EarthbeamDAG task-group, the downstream tasks do not clear automatically.

I _believe_ this fixes the issue.