### PR TITLE
Remove `provide_context` from kwarg arguments in EarthbeamDAG.build_b…

### DIFF
--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -162,7 +162,6 @@ class EarthbeamDAG:
             task_id=task_id,
             bash_command=bash_command,
             **kwargs,
-            provide_context=True,
             pool=self.pool,
             dag=self.dag
         )


### PR DESCRIPTION
…ash_preprocessing_operator().

This argument is PythonOperator-specific and raises an error when called in a BashOperator.