### PR TITLE
feature/add database connection for Earthmover source as env var

### DIFF
--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -177,6 +177,7 @@ class EarthbeamDAG:
         group_id: Optional[str] = None,
         prefix_group_id: bool = False,
 
+        database_conn_id: Optional[str] = None,
         earthmover_kwargs: Optional[dict] = None,
 
         edfi_conn_id: Optional[str] = None,
@@ -217,6 +218,7 @@ class EarthbeamDAG:
         :param group_id:
         :param prefix_group_id:
 
+        :param database_conn_id:
         :param earthmover_kwargs:
 
         :param edfi_conn_id:
@@ -335,6 +337,7 @@ class EarthbeamDAG:
                 earthmover_path=self.earthmover_path,
                 output_dir=em_output_dir,
                 state_file=em_state_file,
+                database_conn_id=database_conn_id,
                 results_file=em_results_file if logging_table else None,
                 **(earthmover_kwargs or {}),
                 pool=self.earthmover_pool,

--- a/edu_edfi_airflow/providers/earthbeam/operators.py
+++ b/edu_edfi_airflow/providers/earthbeam/operators.py
@@ -25,6 +25,7 @@ class EarthmoverOperator(BashOperator):
         selector   : Optional[Union[str, Iterable[str]]] = None,
         parameters : Optional[Union[str, dict]] = None,
         results_file: Optional[str] = None,
+        database_conn_id: Optional[str] = None,
 
         force          : bool = False,
         skip_hashing   : bool = False,
@@ -36,6 +37,7 @@ class EarthmoverOperator(BashOperator):
         self.earthmover_path = earthmover_path
         self.output_dir = output_dir
         self.state_file = state_file
+        self.database_conn_id = database_conn_id
 
         ### Building the Earthmover CLI command
         self.arguments = {}
@@ -84,6 +86,14 @@ class EarthmoverOperator(BashOperator):
         :param context:
         :return:
         """
+        # Construct a database connection string and add as an environment variable if defined
+        # This database connection is used as a source for Earthmover. Currently only Snowflake is supported
+        # (This must be done in execute to prevent extraction during DAG-parsing)
+        if self.database_conn_id:
+            db_conn = Connection.get_connection_from_secrets(self.database_conn_id)
+            database_conn_string = f"snowflake://{db_conn.login}:{db_conn.password}@{db_conn.extra_dejson['extra__snowflake__account']}"
+            self.env['DATABASE_CONNECTION'] = database_conn_string
+
         # Update final Earthmover command with any passed arguments
         # This update occurs here instead of init to allow context parameters to be passed.
         self.bash_command += " ".join(f"{kk} {vv}" for kk, vv in self.arguments.items())


### PR DESCRIPTION
## Description & motivation
The [Istation bundle](https://github.com/edanalytics/earthmover_edfi_bundles/blob/feature/istation__em_refactor/assessments/iStation/earthmover.yml) optionally uses a query as the source of the student ID xwalk. When I implemented the Earthbeam dag for Istation in GSN, I passed the SQLAlchemy database connection string as an Earthmover parameter. Airflow masked the password in the rendered template and logs, but it was exposed in the Task Instance Details. 

I took inspiration from how the Earthbeam dag handles the Ed-Fi connection parameters for Lightbeam by setting them as environment variables. This is working, but I haven't thought deeply about whether the Earthbeam dag is the right place to be handling this. If you have other ideas for how or where we could handle this, I would appreciate them!

## Changes to existing models:
- `earthbeam_dag.py` : Add `database_conn_id` parameter and pass it to the Earthmover operator
- `operators.py` : Use the `database_conn_id` to construct a SQLAlchemy Snowflake connection string and set it as an environment variable

## Tests and QC done:
- Successfully ran for Istation in GSN. Verified that the student ID mapping that uses the database connection was working as expected. The database credentials were were not exposed in the task instance details, rendered template, or logs.

## Future ToDos & Questions:
- Snowflake is currently the only supported database type. We could add flexibility later to allow for other types of database connections as use cases emerge.

## PR Merge Priority:
- [x] Medium - we would like to get the Istation dag working for GSN by the end of the month