### PR TITLE
Feature/dynamic default dag params

### DIFF
--- a/edu_edfi_airflow/dags/edfi_resource_dag.py
+++ b/edu_edfi_airflow/dags/edfi_resource_dag.py
@@ -45,7 +45,7 @@ class EdFiResourceDAG:
         dbt_incrementer_var: str = None,
 
         full_refresh: bool = False,
-        endpoints: [],
+        endpoints: list = [],
 
         **kwargs
     ) -> None:

--- a/edu_edfi_airflow/dags/edfi_resource_dag.py
+++ b/edu_edfi_airflow/dags/edfi_resource_dag.py
@@ -24,19 +24,6 @@ class EdFiResourceDAG:
     newest_edfi_cv_task_id = "get_latest_edfi_change_version"  # Original name for historic run compatibility
     previous_snowflake_cv_task_id = "get_previous_change_versions_from_snowflake"
 
-    params_dict = {
-        "full_refresh": Param(
-            default=False,
-            type="boolean",
-            description="If true, deletes endpoint data in Snowflake before ingestion"
-        ),
-        "endpoints": Param(
-            default=[],
-            type="array",
-            description="Newline-separated list of specific endpoints to ingest (case-agnostic)\n(Bug: even if unused, enter a newline)"
-        ),
-    }
-
     def __init__(self,
         *,
         tenant_code: str,
@@ -57,6 +44,9 @@ class EdFiResourceDAG:
         slack_conn_id: str = None,
         dbt_incrementer_var: str = None,
 
+        full_refresh: bool = False,
+        endpoints: [],
+
         **kwargs
     ) -> None:
         self.tenant_code = tenant_code
@@ -75,6 +65,22 @@ class EdFiResourceDAG:
         self.change_version_table = change_version_table
 
         self.dbt_incrementer_var = dbt_incrementer_var
+
+        self.full_refresh = full_refresh
+        self.endpoints = endpoints
+
+        self.params_dict = {
+        "full_refresh": Param(
+            default=self.full_refresh,
+            type="boolean",
+            description="If true, deletes endpoint data in Snowflake before ingestion"
+        ),
+        "endpoints": Param(
+            default=self.endpoints,
+            type="array",
+            description="Newline-separated list of specific endpoints to ingest (case-agnostic)\n(Bug: even if unused, enter a newline)"
+        ),
+        }
 
         # Initialize the DAG scaffolding for TaskGroup declaration.
         self.dag = self.initialize_dag(**kwargs)

--- a/edu_edfi_airflow/dags/edfi_resource_dag.py
+++ b/edu_edfi_airflow/dags/edfi_resource_dag.py
@@ -44,8 +44,8 @@ class EdFiResourceDAG:
         slack_conn_id: str = None,
         dbt_incrementer_var: str = None,
 
-        full_refresh: bool = False,
-        endpoints: list = [],
+        default_full_refresh: bool = False,
+        default_endpoints: list = [],
 
         **kwargs
     ) -> None:
@@ -66,17 +66,17 @@ class EdFiResourceDAG:
 
         self.dbt_incrementer_var = dbt_incrementer_var
 
-        self.full_refresh = full_refresh
-        self.endpoints = endpoints
+        self.default_full_refresh = default_full_refresh
+        self.default_endpoints = default_endpoints
 
         self.params_dict = {
         "full_refresh": Param(
-            default=self.full_refresh,
+            default=self.default_full_refresh,
             type="boolean",
             description="If true, deletes endpoint data in Snowflake before ingestion"
         ),
         "endpoints": Param(
-            default=self.endpoints,
+            default=self.default_endpoints,
             type="array",
             description="Newline-separated list of specific endpoints to ingest (case-agnostic)\n(Bug: even if unused, enter a newline)"
         ),


### PR DESCRIPTION
<!---
Provide Title above, ensure it summarizes the work in the PR. Example PR titles templates:
* "feature/ (or build/): describe new functionality"
* "hotfix/: describe issue fix for immediate release"
* "bugfix/ (or fix/): describe issue fix, not necessary for immediate release"
* "docs/: adding or updating documentation"
-->

## Description & motivation
<!---
High level description your PR, and why you're making it. Is this linked to slack thread, Monday board, open
issue, a continuation to a previous PR? Link it here if relevant (use the "#" symbol for issues/PRs).
-->

**NOTE** Erik is not a fan of this approach, because it would require doubling the amount of dags if implemented widely, and could cause issue if two dag runs are happening simultaneously. I may explore one of the following alternatives:
1. can the default for full_refresh be a template, e.g. ```{{day_of_month % 30  == 0}}```?
2. use an external dag called `full_refresh_trigger` that triggers certain dags on certain schedules with `full_refresh: True` as a dag run param

This adds functionality to have individual instances of the EdfiResourceDAG to have different default values for dag params `full_refresh` and `endpoints`.

For example, say you want to continue running daily pulls of only deltas, but also want to add a monthly full refresh. Using this feature, you could configure the following in your Stadium project:

```
edfi_resource_dags:
  boston:
    2024__full_refresh:
      edfi_conn_id: 'edfi_boston_2024'
      schedule_interval: 0 0 * * 6
      default_full_refresh: True
      multiyear: False
      <<: *edfi_resource_dags__default_args
    2024:
      edfi_conn_id: 'edfi_boston_2024'
      schedule_interval: (daily or whatever)
      multiyear: False
      <<: *edfi_resource_dags__default_args
```
(as done in Boston [here ](https://github.com/edanalytics/stadium_boston/compare/main...feature/full_refresh_weekends#diff-d51baf24ebc8891d730ac19913350ebaa046964c9a03e402e81c61433a6d93b3R61-R73))

**Note, you will also need to correctly handle the api_year with code in airflow/dags/edfi_resources_to_snowflake.py**, like so: 
```if dag_vars['full_refresh']:
            api_year = re.sub('__full_refresh', '', api_year)
```
This assumes that you name your dag dict `{api_year}__full_refresh`
(as done in Boston [here](https://github.com/edanalytics/stadium_boston/compare/main...feature/full_refresh_weekends#diff-317c43905091c237413ab15c115c78d6086807174c88c958c79668eb863146c1R58-R60))

As a result, you'll have two dags that pull from the 2024 Ed-Fi connection: one that defaults to full_refresh: False, and one that defaults to full_refresh: True. Either can be overridden with dag run params at trigger-time, but having different default values allows each to run on a schedule.

You could also use this to run certain endpoints on a different schedule, e.g. pull student attendance 2x per day, while pulling all other resources 1x per day.

## PR Merge Priority:
<!---
This checklist helps the reviewers understand the level of priority for merging this PR.
A loose description of merging priority levels is:
Low: A week or more.
Medium: Within 3 days or less.
High: As soon as possible.
-->
- [x] Low
- [ ] Medium
- [ ] High

<!---
If High Priority, explain why as a comment below.
-->

## Changes to existing files:
<!---
Include this section if you are changing any existing files or creating breaking changes to existing files. Label the model name and describe the logic behind the changes made, try to be very descriptive here. For example:
- `stg_model` : Describe any changes made to `stg_model` and why the changes where made.
- `src_staging` : Describe any changes made to `src_staging` and why the changes where made.
-->
- `edfi_resource_dag.py`: add two new **required** vars, `full_refresh` and `endpoints`, and have those fill in the default values for `params_dict`, which is later passed at DAG initialization.

## Tests and QC done:
<!---
Describe any process that confirms that the files do what is expected, include screenshots if relevant. For example:
- Analyst replication confirmed that updates to `stg_model` new counts were correct.
- Executed a dbt project run and ensured it was successful.
-->

Tested in Boston, created a new dag for full refresh that runs on a separate schedule. See PR here: https://github.com/edanalytics/stadium_boston/pull/61

## Future ToDos & Questions:
Is there a way to make  `full_refresh` and `endpoints` Optional vars, so this change is not breaking to all existing implementations?

Does this create any dangerous possible cases, e.g. if you have a full refresh run concurrent with a deltas run, what would happen?

Any other default params we should add for these use cases? e.g. should dag construction or priority orders be configurable in this way?
