### PR TITLE
Rc/0.3.0  get cv failed sentinel

### DIFF
--- a/edu_edfi_airflow/dags/edfi_resource_dag.py
+++ b/edu_edfi_airflow/dags/edfi_resource_dag.py
@@ -369,7 +369,7 @@ class EdFiResourceDAG:
             failed_sentinel = PythonOperator(
                 task_id=f"{task_id}__failed_total_counts",
                 python_callable=fail_if_xcom,
-                op_args=airflow_util.xcom_pull_template(get_cv_operator, key='failed_endpoints'),
+                op_args=[airflow_util.xcom_pull_template(get_cv_operator, key='failed_endpoints')],
                 trigger_rule='all_done',
                 dag=self.dag
             )


### PR DESCRIPTION
Add sentinel task in dynamic get_last_cv_operator runs to account for failed total-count endpoints. This should not be necessary, but we encountered a bug where a downstream "none_skipped" task skipped with "upstream_failed" status. More testing is needed, and hopefully this feature can be removed in a future hotfix.