### PR TITLE
Rc/0.3.0  non cv dynamic edfi  dynamic default

### DIFF
--- a/edu_edfi_airflow/dags/edfi_resource_dag.py
+++ b/edu_edfi_airflow/dags/edfi_resource_dag.py
@@ -584,6 +584,7 @@ class EdFiResourceDAG:
                     get_deletes=get_deletes,
                     get_key_changes=get_key_changes
                 )
+                enabled_endpoints = self.xcom_pull_template_map_idx(get_cv_operator, 0)
                 kwargs_dicts = get_cv_operator.output.map(lambda endpoint__cv: {
                     'resource': endpoint__cv[0],
                     'min_change_version': endpoint__cv[1],
@@ -598,6 +599,7 @@ class EdFiResourceDAG:
             # Otherwise, iterate all endpoints.
             else:
                 get_cv_operator = None
+                enabled_endpoints = endpoints
                 kwargs_dicts = list(map(lambda endpoint: {
                     'resource': endpoint,
                     'min_change_version': None,
@@ -623,6 +625,9 @@ class EdFiResourceDAG:
                     get_deletes=get_deletes,
                     get_key_changes=get_key_changes,
                     max_change_version=airflow_util.xcom_pull_template(self.newest_edfi_cv_task_id),
+
+                    # Only run endpoints specified at DAG or delta-level.
+                    enabled_endpoints=enabled_endpoints,
 
                     sla=None,  # "SLAs are unsupported with mapped tasks."
                     pool=self.pool,

--- a/edu_edfi_airflow/dags/edfi_resource_dag.py
+++ b/edu_edfi_airflow/dags/edfi_resource_dag.py
@@ -412,7 +412,7 @@ class EdFiResourceDAG:
         Many XComs in this DAG are lists of tuples. This converts the XCom to a dictionary and returns the value for a given key.
         """
         return airflow_util.xcom_pull_template(
-            task_ids, prefix="dict(", suffix=f")['{key}']"
+            task_ids, prefix="dict(", suffix=f").get('{key}')"
         )
 
 
@@ -491,6 +491,8 @@ class EdFiResourceDAG:
                     num_retries=endpoint_configs.get('num_retries', self.DEFAULT_MAX_RETRIES),
                     change_version_step_size=endpoint_configs.get('change_version_step_size', self.DEFAULT_CHANGE_VERSION_STEP_SIZE),
                     query_parameters={**endpoint_configs.get('params', {}), **self.default_params},
+
+                    ingest_endpoint=self.xcom_pull_template_get_key(get_cv_operator, endpoint) if get_cv_operator else True,  # Returns None if not found.
 
                     pool=self.pool,
                     trigger_rule='none_skipped',

--- a/edu_edfi_airflow/dags/edfi_resource_dag.py
+++ b/edu_edfi_airflow/dags/edfi_resource_dag.py
@@ -432,8 +432,6 @@ class EdFiResourceDAG:
         Build one EdFiToS3 task per endpoint
         Bulk copy the data to its respective table in Snowflake.
 
-        len(get_cv_operator.input) == len(get_cv_operator.output) == len(pull_edfi_to_s3.input) >= len(pull_edfi_to_s3.output) == len(copy_s3_to_snowflake.input)
-
         :param endpoints:
         :param configs:
         :param group_id:
@@ -470,8 +468,6 @@ class EdFiResourceDAG:
             pull_operators_list = []
 
             for endpoint in endpoints:
-                endpoint_configs = configs.get(endpoint, {})
-
                 pull_edfi_to_s3 = EdFiToS3Operator(
                     task_id=endpoint,
                     edfi_conn_id=self.edfi_conn_id,
@@ -488,11 +484,11 @@ class EdFiResourceDAG:
                     max_change_version=airflow_util.xcom_pull_template(self.newest_edfi_cv_task_id),
 
                     # Optional config-specified run-attributes (overridden by those in configs)
-                    namespace=endpoint_configs.get('namespace', self.DEFAULT_NAMESPACE),
-                    page_size=endpoint_configs.get('page_size', self.DEFAULT_PAGE_SIZE),
-                    num_retries=endpoint_configs.get('num_retries', self.DEFAULT_MAX_RETRIES),
-                    change_version_step_size=endpoint_configs.get('change_version_step_size', self.DEFAULT_CHANGE_VERSION_STEP_SIZE),
-                    query_parameters={**endpoint_configs.get('params', {}), **self.default_params},
+                    namespace=configs[endpoint].get('namespace', self.DEFAULT_NAMESPACE),
+                    page_size=configs[endpoint].get('page_size', self.DEFAULT_PAGE_SIZE),
+                    num_retries=configs[endpoint].get('num_retries', self.DEFAULT_MAX_RETRIES),
+                    change_version_step_size=configs[endpoint].get('change_version_step_size', self.DEFAULT_CHANGE_VERSION_STEP_SIZE),
+                    query_parameters={**configs[endpoint].get('params', {}), **self.default_params},
 
                     # Only run endpoints specified at DAG or delta-level.
                     enabled_endpoints=enabled_endpoints,
@@ -553,8 +549,6 @@ class EdFiResourceDAG:
         """
         Build one EdFiToS3 task per endpoint
         Bulk copy the data to its respective table in Snowflake.
-
-        len(get_cv_operator.input) >= len(get_cv_operator.output) == len(pull_edfi_to_s3.input) >= len(pull_edfi_to_s3.output) == len(copy_s3_to_snowflake.input)
 
         :param endpoints:
         :param configs:
@@ -686,8 +680,6 @@ class EdFiResourceDAG:
         """
         Build one EdFiToS3 task (with inner for-loop across endpoints).
         Bulk copy the data to its respective table in Snowflake.
-
-        len(get_cv_operator.input) == len(get_cv_operator.output) == len(pull_edfi_to_s3.input) >= len(pull_edfi_to_s3.output) == len(copy_s3_to_snowflake.input)
 
         :param endpoints:
         :param configs:

--- a/edu_edfi_airflow/providers/edfi/transfers/edfi_to_s3.py
+++ b/edu_edfi_airflow/providers/edfi/transfers/edfi_to_s3.py
@@ -311,12 +311,12 @@ class BulkEdFiToS3Operator(EdFiToS3Operator):
 
             # If doing a resource-specific run, confirm resource is in the list.
             if config_endpoints and resource not in config_endpoints:
-                logging.info("    Endpoint not specified in DAG config endpoints. Skipping...")
+                logging.info(f"    Endpoint {resource} not specified in DAG config endpoints. Skipping...")
                 continue
 
             # Confirm resource is in XCom-list if passed (used for dynamic XComs retrieved from get-change-version operator).
-            if self.enabled_endpoints and self.resource not in self.enabled_endpoints:
-                logging.info("    Endpoint not specified in run endpoints. Skipping...")
+            if self.enabled_endpoints and resource not in self.enabled_endpoints:
+                logging.info(f"    Endpoint {resource} not specified in run endpoints. Skipping...")
                 continue
 
             try:

--- a/edu_edfi_airflow/providers/edfi/transfers/edfi_to_s3.py
+++ b/edu_edfi_airflow/providers/edfi/transfers/edfi_to_s3.py
@@ -27,7 +27,7 @@ class EdFiToS3Operator(BaseOperator):
     template_fields = (
         'resource', 'namespace', 'page_size', 'num_retries', 'change_version_step_size', 'query_parameters',
         's3_destination_key', 's3_destination_dir', 's3_destination_filename',
-        'min_change_version', 'max_change_version', 'ingest_endpoint',
+        'min_change_version', 'max_change_version', 'enabled_endpoints',
     )
 
     def __init__(self,
@@ -52,7 +52,7 @@ class EdFiToS3Operator(BaseOperator):
         change_version_step_size: int = 50000,
         query_parameters  : Optional[dict] = None,
 
-        ingest_endpoint: Optional[bool] = True,
+        enabled_endpoints: Optional[List[str]] = None,
 
         **kwargs
     ) -> None:
@@ -82,7 +82,7 @@ class EdFiToS3Operator(BaseOperator):
         self.query_parameters = query_parameters
 
         # Optional variable to allow immediate skips when endpoint not specified in dynamic get-change-version output.
-        self.ingest_endpoint = ingest_endpoint
+        self.enabled_endpoints = enabled_endpoints
 
 
     def execute(self, context) -> str:
@@ -96,11 +96,9 @@ class EdFiToS3Operator(BaseOperator):
         if config_endpoints and self.resource not in config_endpoints:
             raise AirflowSkipException("Endpoint not specified in DAG config endpoints.")
         
-        # Skip immediately if XCom is defined for endpoint (used for dynamic XComs retrieved from get-change-version operator).
-        # This value is the last change-version, so falsy boolean checks cannot be made.
-        if self.ingest_endpoint is None:
-            raise AirflowSkipException("Endpoint explicitly marked as skipped.")
-
+        # Confirm resource is in XCom-list if passed (used for dynamic XComs retrieved from get-change-version operator).
+        if self.enabled_endpoints and self.resource not in self.enabled_endpoints:
+            raise AirflowSkipException("Endpoint not specified in run endpoints.")
         # Optionally set destination key by concatting separate args for dir and filename
         if not self.s3_destination_key:
             if not (self.s3_destination_dir and self.s3_destination_filename):
@@ -259,12 +257,15 @@ class BulkEdFiToS3Operator(EdFiToS3Operator):
     """
     Inherits from EdFiToS3Operator to reduce code-duplication.
 
-    Establish a connection to the EdFi ODS using an Airflow Connection.
-    Default to pulling the EdFi API configs from the connection if not explicitly provided.
-
-    Use a paged-get to retrieve a list of resources from the ODS.
-    Save the results as JSON lines to `tmp_dir` on the server.
-    Once pagination is complete, write the full results to S3.
+    The following arguments MUST be lists instead of singletons:
+    - resource
+    - namespace
+    - page_size
+    - num_retries
+    - change_version_step_size
+    - query_parameters
+    - min_change_version
+    - s3_destination_filename
 
     If all endpoints skip, raise an AirflowSkipException.
     If at least one endpoint fails, push the XCom and raise an AirflowFailException.
@@ -276,42 +277,17 @@ class BulkEdFiToS3Operator(EdFiToS3Operator):
         :param context:
         :return:
         """
-        # Force potential string columns into lists for zipping in execute.
-        if isinstance(self.resource, str):
-            raise AirflowFailException("Bulk operators require lists of resources to be passed.")
-
-        if isinstance(self.namespace, str):
-            self.namespace = [self.namespace] * len(self.resource)
-
-        if isinstance(self.page_size, int):
-            self.page_size = [self.page_size] * len(self.resource)
-
-        if isinstance(self.num_retries, int):
-            self.num_retries = [self.num_retries] * len(self.resource)
-
-        if isinstance(self.change_version_step_size, int):
-            self.change_version_step_size = [self.change_version_step_size] * len(self.resource)
-
-        if isinstance(self.query_parameters, dict):
-            self.query_parameters = [self.query_parameters] * len(self.resource)
-
-        if isinstance(self.min_change_version, (int, type(None))):
-            self.min_change_version = [self.min_change_version] * len(self.resource)
-
         # Force destination_dir and destination_filename arguments to be used.
         if self.s3_destination_key or not (self.s3_destination_dir and self.s3_destination_filename):
             raise ValueError(
                 "Bulk operators require arguments `s3_destination_dir` and `s3_destination_filename` to be passed."
             )
 
-        if isinstance(self.s3_destination_filename, str):
-            raise ValueError(
-                "Bulk operators require a list to be passed in argument `s3_destination_filename`."
-            )
-
-        # Begin actual processing of defined endpoints.
-        config_endpoints = airflow_util.get_config_endpoints(context)
+        # Make connection outside of loop to not re-authenticate at every resource.
         edfi_conn = EdFiHook(self.edfi_conn_id).get_conn()
+
+        # Gather DAG-level endpoints outside of loop.
+        config_endpoints = airflow_util.get_config_endpoints(context)
 
         return_tuples = []
         failed_endpoints = []  # Track which endpoints failed during ingestion.
@@ -335,7 +311,12 @@ class BulkEdFiToS3Operator(EdFiToS3Operator):
 
             # If doing a resource-specific run, confirm resource is in the list.
             if config_endpoints and resource not in config_endpoints:
-                logging.info(f"    Endpoint {resource} not specified in DAG config endpoints. Skipping...")
+                logging.info("    Endpoint not specified in DAG config endpoints. Skipping...")
+                continue
+
+            # Confirm resource is in XCom-list if passed (used for dynamic XComs retrieved from get-change-version operator).
+            if self.enabled_endpoints and self.resource not in self.enabled_endpoints:
+                logging.info("    Endpoint not specified in run endpoints. Skipping...")
                 continue
 
             try:


### PR DESCRIPTION
- Make total-count GETs for deltas required for all task-groups to reduce unnecessary calls to the API.
- Add `enabled_endpoints` filter to `EdFiToS3Operator` to skip endpoints not marked to be processed.