### PR TITLE
Rc/0.3.0  sentinel trigger

### DIFF
--- a/edu_edfi_airflow/callables/airflow_util.py
+++ b/edu_edfi_airflow/callables/airflow_util.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Tuple, Union
 
 from airflow.exceptions import AirflowFailException
 from airflow.models import Connection
-from airflow.models.baseoperator import chain_linear
+from airflow.models.baseoperator import chain
 
 from edfi_api_client import camel_to_snake
 
@@ -145,7 +145,7 @@ def chain_tasks(*tasks):
     Alias of airflow's built-in chain, but remove Nones if present.
     Note: this recurses only one level.
     """
-    chain_linear(*recursive_filter(None, tasks))
+    chain(*recursive_filter(None, tasks))
 
 def recursive_filter(func, iterable):
     """

--- a/edu_edfi_airflow/callables/airflow_util.py
+++ b/edu_edfi_airflow/callables/airflow_util.py
@@ -5,7 +5,7 @@ from typing import List, Optional, Tuple, Union
 
 from airflow.exceptions import AirflowFailException
 from airflow.models import Connection
-from airflow.models.baseoperator import chain
+from airflow.models.baseoperator import chain_linear
 
 from edfi_api_client import camel_to_snake
 
@@ -145,7 +145,7 @@ def chain_tasks(*tasks):
     Alias of airflow's built-in chain, but remove Nones if present.
     Note: this recurses only one level.
     """
-    chain(*recursive_filter(None, tasks))
+    chain_linear(*recursive_filter(None, tasks))
 
 def recursive_filter(func, iterable):
     """

--- a/edu_edfi_airflow/dags/edfi_resource_dag.py
+++ b/edu_edfi_airflow/dags/edfi_resource_dag.py
@@ -314,8 +314,9 @@ class EdFiResourceDAG:
             dag=self.dag
         )
 
-        # Chain tasks and taskgroups into the DAG
-        airflow_util.chain_tasks(cv_task_group, edfi_task_groups, [dbt_var_increment_operator, dag_state_sentinel])
+        # Chain tasks and taskgroups into the DAG; chain sentinel after all task groups.
+        airflow_util.chain_tasks(cv_task_group, edfi_task_groups, dbt_var_increment_operator)
+        airflow_util.chain_tasks(edfi_task_groups, dag_state_sentinel)
 
 
     ### Internal methods that should not be called directly.

--- a/edu_edfi_airflow/dags/edfi_resource_dag.py
+++ b/edu_edfi_airflow/dags/edfi_resource_dag.py
@@ -315,7 +315,7 @@ class EdFiResourceDAG:
         )
 
         # Chain tasks and taskgroups into the DAG
-        airflow_util.chain_tasks(cv_task_group, edfi_task_groups, dbt_var_increment_operator, dag_state_sentinel)
+        airflow_util.chain_tasks(cv_task_group, edfi_task_groups, [dbt_var_increment_operator, dag_state_sentinel])
 
 
     ### Internal methods that should not be called directly.


### PR DESCRIPTION
Fix minor bug where DAG sentinel could finish before all tasks were completed. An alternative option in the future would be a deferable operator that sleeps while waiting for tasks to finish.