### PR TITLE
Feature: partitioning pre-processing function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+- Add `partition_on_tenant_and_year`, a preprocessing function to shard data to parquet on disk. This is useful when a single input file contains multiple years and/or tenants.
+
 # edu_edfi_airflow v0.3.0
 ## New features
 - Add `/keyChanges` ingestion for resource endpoints

--- a/README.md
+++ b/README.md
@@ -619,3 +619,26 @@ This method works on both filepaths and directory paths.
 -----
 
 </details>
+
+## Plug-and-play preprocessing functions
+
+Static methods provided by `EarthbeamDAG` that can be provided as callables Python preprocessing operators
+
+### partition_on_tenant_and_year
+Shards data to parquet on disk. This is useful when a single input file contains multiple years and/or tenants.
+
+<details>
+<summary>Arguments:</summary>
+
+| Argument    | Description                                                                 |
+|:------------|:----------------------------------------------------------------------------|
+| csv_paths   | one or more complete file paths pointing to input data                      |
+| output_dir  | root directory of the parquet                                               |
+| tenant_col  | (optional) name of the column to use as tenant code                         |
+| tenant_map  | (optional) map values from the contents of tenant_col to valid tenant codes |
+| year_col    | (optional) name of the column to use as API year                            |
+| year_map    | (optional) map values from the contents of api_col to valid API years       |
+
+-----
+
+</details>

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -122,19 +122,16 @@ class EarthbeamDAG:
             for csv_path, parquet_path in path_mapping.items():
                 df = dd.read_csv(csv_path, dtype=str, na_filter=False).fillna('')
 
-                # FIXME: should be able to map even if names match, ugh
                 # if needed, add tenant_code and api_year as columns so we can partition on them
-                if tenant_col != tenant_code:
-                    if tenant_map is not None:
-                        df[tenant_code] = df[tenant_col].map(lambda x: tenant_map[x], meta=dd.utils.make_meta(df[tenant_col]))
-                    else:
-                        df[tenant_code] = df[tenant_col]
+                if tenant_map is not None:
+                    df[tenant_code] = df[tenant_col].map(lambda x: tenant_map[x], meta=dd.utils.make_meta(df[tenant_col]))
+                else:
+                    df[tenant_code] = df[tenant_col]
 
-                if year_col != api_year:
-                    if year_map is not None:
-                        df[api_year] = df[year_col].map(lambda x: year_map[x], meta=dd.utils.make_meta(df[year_col]))
-                    else:
-                        df[api_year] = df[year_col]
+                if year_map is not None:
+                    df[api_year] = df[year_col].map(lambda x: year_map[x], meta=dd.utils.make_meta(df[year_col]))
+                else:
+                    df[api_year] = df[year_col]
 
                 df.to_parquet(parquet_path, write_index=False, overwrite=True, partition_on=[tenant_code, api_year])
 

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -102,6 +102,7 @@ class EarthbeamDAG:
                     logging.warning(f"File does not match file_pattern: {file}")
                     unmatched_files.append(os.path.join(root, file))
                     continue
+
                 return_files.append(os.path.join(root, file))
 
         # Push an additional XCom if one or more files failed the file-pattern check.

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -6,9 +6,6 @@ from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator
 from airflow.utils.helpers import chain
 from airflow.utils.task_group import TaskGroup
-import dask
-import dask.dataframe as dd
-import pandas as pd
 
 import edfi_api_client
 from ea_airflow_util import EACustomDAG
@@ -90,6 +87,11 @@ class EarthbeamDAG:
         year_col: str = "api_year",
         year_map: dict = None,
     ):
+        # (expensive) imports here so that the airflow scheduler doesn't have to deal with them
+        import dask
+        import dask.dataframe as dd
+        import pandas as pd
+
         tenant_code = "tenant_code"
         api_year = "api_year"
 

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -199,6 +199,7 @@ class EarthbeamDAG:
             dag=self.dag
         )
 
+
     def build_tenant_year_taskgroup(self,
         tenant_code: str,
         api_year: int,
@@ -288,6 +289,7 @@ class EarthbeamDAG:
             elif s3_conn_id:         # Earthmover-to-S3
                 group_id += "_to_s3"
 
+
         with TaskGroup(
             group_id=group_id,
             prefix_group_id=prefix_group_id,
@@ -311,6 +313,7 @@ class EarthbeamDAG:
 
                 task_order.append(python_preprocess)
                 paths_to_clean.append(airflow_util.xcom_pull_template(python_preprocess.task_id))
+
 
             ### Raw to S3
             if s3_conn_id:
@@ -340,6 +343,7 @@ class EarthbeamDAG:
                 )
 
                 task_order.append(raw_to_s3)
+
 
             ### EarthmoverOperator: Required
             em_output_dir = edfi_api_client.url_join(
@@ -376,6 +380,7 @@ class EarthbeamDAG:
             task_order.append(run_earthmover)
             paths_to_clean.append(airflow_util.xcom_pull_template(run_earthmover.task_id))
 
+
             ### Earthmover logs to Snowflake
             if logging_table:
                 if not snowflake_conn_id:
@@ -402,6 +407,7 @@ class EarthbeamDAG:
                 )
 
                 run_earthmover >> log_earthmover_to_snowflake
+
 
             ### Earthmover to S3
             if s3_conn_id:
@@ -431,6 +437,7 @@ class EarthbeamDAG:
                 )
 
                 task_order.append(em_to_s3)
+
 
             ### LightbeamOperator
             if edfi_conn_id:
@@ -487,6 +494,7 @@ class EarthbeamDAG:
                     )
 
                     run_lightbeam >> log_lightbeam_to_snowflake
+
 
             ### Alternate route: Bypassing the ODS directly into Snowflake
             if snowflake_conn_id and not edfi_conn_id:
@@ -547,6 +555,7 @@ class EarthbeamDAG:
 
                 task_order.append(s3_to_snowflake_task_group)
 
+
             ### Final cleanup
             cleanup_local_disk = PythonOperator(
                 task_id=f"{taskgroup_grain}_cleanup_disk",
@@ -566,6 +575,7 @@ class EarthbeamDAG:
             chain(*task_order)
 
         return tenant_year_task_group
+
 
     def insert_earthbeam_result_to_logging_table(self,
         snowflake_conn_id: str,

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -108,23 +108,16 @@ class EarthbeamDAG:
         tenant_code = "tenant_code"
         api_year = "api_year"
 
-        input_is_list = True if isinstance(csv_paths, list) else False
+        csv_paths = csv_paths if isinstance(csv_paths, list) else [csv_paths]
 
-        final_csv_paths = []
-        if input_is_list:
-            final_csv_paths = csv_paths
-        else:
-            # otherwise we have a string, so wrap it in a list
-            final_csv_paths = [csv_paths]
-
-        for csv_path in final_csv_paths:
+        for csv_path in csv_paths:
             if not Path(csv_path).is_file() or not Path(csv_path).suffix == '.csv':
                 raise ValueError(f"Input path '{csv_path}' is not a path to a file whose name ends with '.csv'")
 
         path_mapping = {
             # use the input file basenames as the parquet directory names
             csv_path: PurePath(output_dir, PurePath(csv_path).name).with_suffix('')
-            for csv_path in final_csv_paths
+            for csv_path in csv_paths
         }
 
         Path(output_dir).mkdir(exist_ok=True)

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -80,8 +80,7 @@ class EarthbeamDAG:
 
     @staticmethod
     def partition_on_tenant_and_year(
-        # FIXME: can take a path too
-        csv_paths: Union[str, List[str]],
+        csv_paths: Union[Union[str, Path], List[Union[str, Path]]],
         output_dir: str,
         tenant_col: str = "tenant_code",
         tenant_map: dict = None,

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -62,6 +62,7 @@ class EarthbeamDAG:
 
         self.dag = EACustomDAG(params=self.params_dict, **kwargs)
 
+
     def build_local_raw_dir(self, tenant_code: str, api_year: int, grain_update: Optional[str] = None) -> str:
         """
         Helper function to force consistency when building raw filepathing in Python operators.

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -1,12 +1,8 @@
-<<<<<<< HEAD
 from pathlib import Path, PurePath
-from typing import Callable, List, Optional, Union
-=======
 from typing import Callable, List, Optional, Union
 import logging
 import os
 import re
->>>>>>> 123ecb07ff822c326412f7870a8ac44f436783bf
 
 
 from airflow.decorators import task, task_group

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -144,12 +144,12 @@ class EarthbeamDAG:
             
                 # if needed, add tenant_code and api_year as columns so we can partition on them
                 if tenant_map is not None:
-                    df[tenant_code] = df[tenant_col].map(lambda x: tenant_map[x], meta=dd.utils.make_meta(df[tenant_col]))
+                    df[tenant_code] = df[tenant_col].map(tenant_map, meta=dd.utils.make_meta(df[tenant_col]))
                 else:
                     df[tenant_code] = df[tenant_col]
 
                 if year_map is not None:
-                    df[api_year] = df[year_col].map(lambda x: year_map[x], meta=dd.utils.make_meta(df[year_col]))
+                    df[api_year] = df[year_col].map(year_map, meta=dd.utils.make_meta(df[year_col]))
                 else:
                     df[api_year] = df[year_col]
 

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -128,7 +128,8 @@ class EarthbeamDAG:
         year_map: dict = None,
     ):
         """
-        Preprocessing function to shard data to parquet on disk
+        Preprocessing function to shard data to parquet on disk.
+        This is useful when a single input file contains multiple years and/or tenants.
 
         :param csv_paths: one or more complete file paths pointing to input data
         :param output_dir: root directory of the parquet

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths =
+    tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,15 @@
+pytest 
+pytest-sugar
+pandas
+apache-airflow
+apache-airflow-providers-slack
+boto3
+airflow_dbt
+apache-airflow-providers-amazon
+apache-airflow-providers-snowflake
+apache-airflow-providers-sftp
+pysftp
+dask[dataframe]
+apache-airflow-providers-postgres
+edfi_api_client
+ea_airflow_util

--- a/tests/test_earthbeam.py
+++ b/tests/test_earthbeam.py
@@ -1,0 +1,197 @@
+import pandas as pd
+import pytest
+
+from edu_edfi_airflow.dags.earthbeam_dag import EarthbeamDAG
+
+def test_data_small():
+    return pd.DataFrame({
+        'id': [i for i in range(6)],
+        'tenant_code': (['demo_tenant' ] * 3) + (['demo_tenant_2'] * 3),
+        'api_year': (['1999'] * 2) + (['2000'] * 2) + (['2001'] * 2)
+    })
+
+def test_partition_basic(tmp_path):
+    data_filename = 'data'
+    data_path = tmp_path / f'{data_filename}.csv'
+
+    test_data_small().to_csv(data_path, index=False)
+
+    EarthbeamDAG.partition_on_tenant_and_year(data_path, tmp_path)
+
+    assert (tmp_path / data_filename / "tenant_code=demo_tenant").is_dir()
+    assert (tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=1999").is_dir()
+    assert any((tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=1999").iterdir())
+
+    assert (tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=2000").is_dir()
+    assert not (tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=2001").is_dir()
+
+    assert (tmp_path / data_filename / "tenant_code=demo_tenant_2").is_dir()
+    assert not (tmp_path / data_filename / "tenant_code=demo_tenant_2" / "api_year=1999").is_dir()
+    assert (tmp_path / data_filename / "tenant_code=demo_tenant_2" / "api_year=2000").is_dir()
+    assert (tmp_path / data_filename / "tenant_code=demo_tenant_2" / "api_year=2001").is_dir()
+
+def test_partition_list_of_csvs(tmp_path):
+    simple_data = {
+        'id': [i for i in range(6)],
+        'tenant_code': (['demo_tenant' ] * 3) + (['demo_tenant_2'] * 3),
+        'api_year': (['1999'] * 2) + (['2000'] * 2) + (['2001'] * 2)
+    }
+
+    # TODO: bad names
+    data_file_1 = "data_file_1"
+    data_file_2 = "data_file_2"
+    data_file_3 = "data_file_3"
+
+    data_path_1 = tmp_path / f'{data_file_1}.csv'
+    data_path_2 = tmp_path / f'{data_file_2}.csv'
+    data_path_3 = tmp_path / f'{data_file_3}.csv'
+
+    pd.DataFrame(simple_data).to_csv(data_path_1, index=False)
+    pd.DataFrame(simple_data).to_csv(data_path_2, index=False)
+    pd.DataFrame(simple_data).to_csv(data_path_3, index=False)
+
+    EarthbeamDAG.partition_on_tenant_and_year([data_path_1, str(data_path_2), data_path_3], tmp_path)
+
+    assert (tmp_path / data_file_1 / "tenant_code=demo_tenant").is_dir()
+    assert (tmp_path / data_file_1 / "tenant_code=demo_tenant" / "api_year=1999").is_dir()
+    assert any((tmp_path / data_file_1 / "tenant_code=demo_tenant" / "api_year=1999").iterdir())
+
+    assert (tmp_path / data_file_1 / "tenant_code=demo_tenant" / "api_year=2000").is_dir()
+    assert not (tmp_path / data_file_1 / "tenant_code=demo_tenant" / "api_year=2001").is_dir()
+
+    assert (tmp_path / data_file_1 / "tenant_code=demo_tenant_2").is_dir()
+    assert not (tmp_path / data_file_1 / "tenant_code=demo_tenant_2" / "api_year=1999").is_dir()
+    assert (tmp_path / data_file_1 / "tenant_code=demo_tenant_2" / "api_year=2000").is_dir()
+    assert (tmp_path / data_file_1 / "tenant_code=demo_tenant_2" / "api_year=2001").is_dir()
+
+
+    assert (tmp_path / data_file_2 / "tenant_code=demo_tenant").is_dir()
+    assert (tmp_path / data_file_2 / "tenant_code=demo_tenant" / "api_year=1999").is_dir()
+    assert any((tmp_path / data_file_2 / "tenant_code=demo_tenant" / "api_year=1999").iterdir())
+
+    assert (tmp_path / data_file_2 / "tenant_code=demo_tenant" / "api_year=2000").is_dir()
+    assert not (tmp_path / data_file_2 / "tenant_code=demo_tenant" / "api_year=2001").is_dir()
+
+    assert (tmp_path / data_file_2 / "tenant_code=demo_tenant_2").is_dir()
+    assert not (tmp_path / data_file_2 / "tenant_code=demo_tenant_2" / "api_year=1999").is_dir()
+    assert (tmp_path / data_file_2 / "tenant_code=demo_tenant_2" / "api_year=2000").is_dir()
+    assert (tmp_path / data_file_2 / "tenant_code=demo_tenant_2" / "api_year=2001").is_dir()
+
+
+    assert (tmp_path / data_file_3 / "tenant_code=demo_tenant").is_dir()
+    assert (tmp_path / data_file_3 / "tenant_code=demo_tenant" / "api_year=1999").is_dir()
+    assert any((tmp_path / data_file_3 / "tenant_code=demo_tenant" / "api_year=1999").iterdir())
+
+    assert (tmp_path / data_file_3 / "tenant_code=demo_tenant" / "api_year=2000").is_dir()
+    assert not (tmp_path / data_file_3 / "tenant_code=demo_tenant" / "api_year=2001").is_dir()
+
+    assert (tmp_path / data_file_3 / "tenant_code=demo_tenant_2").is_dir()
+    assert not (tmp_path / data_file_3 / "tenant_code=demo_tenant_2" / "api_year=1999").is_dir()
+    assert (tmp_path / data_file_3 / "tenant_code=demo_tenant_2" / "api_year=2000").is_dir()
+    assert (tmp_path / data_file_3 / "tenant_code=demo_tenant_2" / "api_year=2001").is_dir()
+
+def test_partition_col_names(tmp_path):
+    data_filename = 'data'
+    data_path = tmp_path / f'{data_filename}.csv'
+
+    test_data_small().to_csv(data_path, index=False)
+
+    EarthbeamDAG.partition_on_tenant_and_year(data_path, tmp_path, tenant_col="name", year_col="data_year")
+
+    assert (tmp_path / data_filename / "tenant_code=demo_tenant").is_dir()
+    assert (tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=1999").is_dir()
+    assert any((tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=1999").iterdir())
+
+    assert (tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=2000").is_dir()
+    assert not (tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=2001").is_dir()
+
+    assert (tmp_path / data_filename / "tenant_code=demo_tenant_2").is_dir()
+    assert not (tmp_path / data_filename / "tenant_code=demo_tenant_2" / "api_year=1999").is_dir()
+    assert (tmp_path / data_filename / "tenant_code=demo_tenant_2" / "api_year=2000").is_dir()
+    assert (tmp_path / data_filename / "tenant_code=demo_tenant_2" / "api_year=2001").is_dir()
+
+def test_partition_col_maps(tmp_path):
+    simple_data = {
+        'id': [i for i in range(6)],
+        'tenant_code': (['dt' ] * 3) + (['dt2'] * 3),
+        'api_year': (['99'] * 2) + (['00'] * 2) + (['01'] * 2)
+    }
+
+    data_filename = 'data'
+    data_path = tmp_path / f'{data_filename}.csv'
+
+    test_data_small().to_csv(data_path, index=False)
+
+    EarthbeamDAG.partition_on_tenant_and_year(data_path, tmp_path, tenant_map={'dt': 'demo_tenant', 'dt2': 'demo_tenant_2'}, year_map={'99': '1999', '00': '2000', '01': '2001'})
+
+    assert (tmp_path / data_filename / "tenant_code=demo_tenant").is_dir()
+    assert (tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=1999").is_dir()
+    assert any((tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=1999").iterdir())
+
+    assert (tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=2000").is_dir()
+    assert not (tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=2001").is_dir()
+
+    assert (tmp_path / data_filename / "tenant_code=demo_tenant_2").is_dir()
+    assert not (tmp_path / data_filename / "tenant_code=demo_tenant_2" / "api_year=1999").is_dir()
+    assert (tmp_path / data_filename / "tenant_code=demo_tenant_2" / "api_year=2000").is_dir()
+    assert (tmp_path / data_filename / "tenant_code=demo_tenant_2" / "api_year=2001").is_dir()
+
+def test_partition_col_names_and_maps(tmp_path):
+    data_filename = 'data'
+    data_path = tmp_path / f'{data_filename}.csv'
+
+    test_data_small().to_csv(data_path, index=False)
+
+    EarthbeamDAG.partition_on_tenant_and_year(data_path, tmp_path, tenant_col="name", tenant_map={'dt': 'demo_tenant', 'dt2': 'demo_tenant_2'}, year_col="data_year", year_map={'99': '1999', '00': '2000', '01': '2001'})
+
+    assert (tmp_path / data_filename / "tenant_code=demo_tenant").is_dir()
+    assert (tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=1999").is_dir()
+    assert any((tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=1999").iterdir())
+
+    assert (tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=2000").is_dir()
+    assert not (tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=2001").is_dir()
+
+    assert (tmp_path / data_filename / "tenant_code=demo_tenant_2").is_dir()
+    assert not (tmp_path / data_filename / "tenant_code=demo_tenant_2" / "api_year=1999").is_dir()
+    assert (tmp_path / data_filename / "tenant_code=demo_tenant_2" / "api_year=2000").is_dir()
+    assert (tmp_path / data_filename / "tenant_code=demo_tenant_2" / "api_year=2001").is_dir()
+
+
+def test_record_in_correct_partition(tmp_path):
+    simple_data = {
+        'id': [i for i in range(6000000)],
+        'tenant_code': (['demo_tenant' ] * 3000000) + ['special_tenant'] + (['demo_tenant_2'] * 2999999),
+        'api_year': (['1999'] * 2000000) + (['2000'] * 2000000) + (['2001'] * 2000000)
+    }
+
+    data_filename = 'data'
+    data_path = tmp_path / f'{data_filename}.csv'
+
+    pd.DataFrame(simple_data).to_csv(data_path, index=False)
+
+    EarthbeamDAG.partition_on_tenant_and_year(data_path, tmp_path)
+
+    df = pd.read_parquet(tmp_path / data_filename / 'tenant_code=special_tenant') 
+
+    assert len(df.index) == 1
+    assert df.loc[df.index[0], 'id'] == '3000000'
+
+def test_partition_invalid_csv(tmp_path):
+    data_filename = 'data'
+
+    # function expects all inputs to be CSVs
+    data_path = tmp_path / f'{data_filename}.yar'
+
+    test_data_small().to_csv(data_path, index=False)
+
+    with pytest.raises(ValueError):
+        EarthbeamDAG.partition_on_tenant_and_year(data_path, tmp_path)
+
+def test_partition_invalid_col(tmp_path):
+    data_filename = 'data'
+    data_path = tmp_path / f'{data_filename}.csv'
+
+    test_data_small().to_csv(data_path, index=False)
+
+    with pytest.raises(KeyError):
+        EarthbeamDAG.partition_on_tenant_and_year(data_path, tmp_path, tenant_col='not_found')

--- a/tests/test_earthbeam.py
+++ b/tests/test_earthbeam.py
@@ -1,197 +1,200 @@
+from pathlib import Path
+
 import pandas as pd
 import pytest
 
 from edu_edfi_airflow.dags.earthbeam_dag import EarthbeamDAG
 
-def test_data_small():
-    return pd.DataFrame({
-        'id': [i for i in range(6)],
-        'tenant_code': (['demo_tenant' ] * 3) + (['demo_tenant_2'] * 3),
-        'api_year': (['1999'] * 2) + (['2000'] * 2) + (['2001'] * 2)
-    })
+DEFAULT_FILE = "data"
 
-def test_partition_basic(tmp_path):
-    data_filename = 'data'
-    data_path = tmp_path / f'{data_filename}.csv'
 
-    test_data_small().to_csv(data_path, index=False)
+@pytest.fixture
+def basic_data():
+    return pd.DataFrame(
+        {
+            "id": [i for i in range(6)],
+            "tenant_code": (["tenant"] * 3) + (["tenant_2"] * 3),
+            "api_year": (["1999"] * 2) + (["2000"] * 2) + (["2001"] * 2),
+        }
+    )
 
+
+def validate_partitions(
+    root,
+    expect=[
+        Path("tenant_code=tenant", "api_year=1999"),
+        Path("tenant_code=tenant", "api_year=2000"),
+        Path("tenant_code=tenant_2", "api_year=2000"),
+        Path("tenant_code=tenant_2", "api_year=2001"),
+    ],
+    expect_not=[
+        Path("tenant_code=tenant", "api_year=2001"),
+        Path("tenant_code=tenant_2", "api_year=1999"),
+    ],
+):
+    for path in expect:
+        assert (root / path).is_dir()
+        assert any((root / path).iterdir())
+
+    for path in expect_not:
+        assert not (root / path).is_dir()
+
+
+def test_partition_basic(tmp_path, basic_data):
+    # arrange
+    data_path = tmp_path / f"{DEFAULT_FILE}.csv"
+    basic_data.to_csv(data_path, index=False)
+
+    # act
     EarthbeamDAG.partition_on_tenant_and_year(data_path, tmp_path)
 
-    assert (tmp_path / data_filename / "tenant_code=demo_tenant").is_dir()
-    assert (tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=1999").is_dir()
-    assert any((tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=1999").iterdir())
+    # assert
+    validate_partitions(tmp_path / DEFAULT_FILE)
 
-    assert (tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=2000").is_dir()
-    assert not (tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=2001").is_dir()
 
-    assert (tmp_path / data_filename / "tenant_code=demo_tenant_2").is_dir()
-    assert not (tmp_path / data_filename / "tenant_code=demo_tenant_2" / "api_year=1999").is_dir()
-    assert (tmp_path / data_filename / "tenant_code=demo_tenant_2" / "api_year=2000").is_dir()
-    assert (tmp_path / data_filename / "tenant_code=demo_tenant_2" / "api_year=2001").is_dir()
-
-def test_partition_list_of_csvs(tmp_path):
-    simple_data = {
-        'id': [i for i in range(6)],
-        'tenant_code': (['demo_tenant' ] * 3) + (['demo_tenant_2'] * 3),
-        'api_year': (['1999'] * 2) + (['2000'] * 2) + (['2001'] * 2)
-    }
-
-    # TODO: bad names
+def test_partition_list_of_csvs(tmp_path, basic_data):
+    # arrange: prepare multiple inputs for one function call
     data_file_1 = "data_file_1"
     data_file_2 = "data_file_2"
     data_file_3 = "data_file_3"
 
-    data_path_1 = tmp_path / f'{data_file_1}.csv'
-    data_path_2 = tmp_path / f'{data_file_2}.csv'
-    data_path_3 = tmp_path / f'{data_file_3}.csv'
+    data_path_1 = tmp_path / f"{data_file_1}.csv"
+    data_path_2 = tmp_path / f"{data_file_2}.csv"
+    data_path_3 = tmp_path / f"{data_file_3}.csv"
 
-    pd.DataFrame(simple_data).to_csv(data_path_1, index=False)
-    pd.DataFrame(simple_data).to_csv(data_path_2, index=False)
-    pd.DataFrame(simple_data).to_csv(data_path_3, index=False)
+    basic_data.to_csv(data_path_1, index=False)
+    basic_data.to_csv(data_path_2, index=False)
+    basic_data.to_csv(data_path_3, index=False)
 
-    EarthbeamDAG.partition_on_tenant_and_year([data_path_1, str(data_path_2), data_path_3], tmp_path)
+    # act: also test mixture of Path objects and strings
+    EarthbeamDAG.partition_on_tenant_and_year(
+        [data_path_1, str(data_path_2), data_path_3], tmp_path
+    )
 
-    assert (tmp_path / data_file_1 / "tenant_code=demo_tenant").is_dir()
-    assert (tmp_path / data_file_1 / "tenant_code=demo_tenant" / "api_year=1999").is_dir()
-    assert any((tmp_path / data_file_1 / "tenant_code=demo_tenant" / "api_year=1999").iterdir())
+    # assert: each input file should get its own parquet
+    validate_partitions(tmp_path / data_file_1)
+    validate_partitions(tmp_path / data_file_2)
+    validate_partitions(tmp_path / data_file_3)
 
-    assert (tmp_path / data_file_1 / "tenant_code=demo_tenant" / "api_year=2000").is_dir()
-    assert not (tmp_path / data_file_1 / "tenant_code=demo_tenant" / "api_year=2001").is_dir()
-
-    assert (tmp_path / data_file_1 / "tenant_code=demo_tenant_2").is_dir()
-    assert not (tmp_path / data_file_1 / "tenant_code=demo_tenant_2" / "api_year=1999").is_dir()
-    assert (tmp_path / data_file_1 / "tenant_code=demo_tenant_2" / "api_year=2000").is_dir()
-    assert (tmp_path / data_file_1 / "tenant_code=demo_tenant_2" / "api_year=2001").is_dir()
-
-
-    assert (tmp_path / data_file_2 / "tenant_code=demo_tenant").is_dir()
-    assert (tmp_path / data_file_2 / "tenant_code=demo_tenant" / "api_year=1999").is_dir()
-    assert any((tmp_path / data_file_2 / "tenant_code=demo_tenant" / "api_year=1999").iterdir())
-
-    assert (tmp_path / data_file_2 / "tenant_code=demo_tenant" / "api_year=2000").is_dir()
-    assert not (tmp_path / data_file_2 / "tenant_code=demo_tenant" / "api_year=2001").is_dir()
-
-    assert (tmp_path / data_file_2 / "tenant_code=demo_tenant_2").is_dir()
-    assert not (tmp_path / data_file_2 / "tenant_code=demo_tenant_2" / "api_year=1999").is_dir()
-    assert (tmp_path / data_file_2 / "tenant_code=demo_tenant_2" / "api_year=2000").is_dir()
-    assert (tmp_path / data_file_2 / "tenant_code=demo_tenant_2" / "api_year=2001").is_dir()
-
-
-    assert (tmp_path / data_file_3 / "tenant_code=demo_tenant").is_dir()
-    assert (tmp_path / data_file_3 / "tenant_code=demo_tenant" / "api_year=1999").is_dir()
-    assert any((tmp_path / data_file_3 / "tenant_code=demo_tenant" / "api_year=1999").iterdir())
-
-    assert (tmp_path / data_file_3 / "tenant_code=demo_tenant" / "api_year=2000").is_dir()
-    assert not (tmp_path / data_file_3 / "tenant_code=demo_tenant" / "api_year=2001").is_dir()
-
-    assert (tmp_path / data_file_3 / "tenant_code=demo_tenant_2").is_dir()
-    assert not (tmp_path / data_file_3 / "tenant_code=demo_tenant_2" / "api_year=1999").is_dir()
-    assert (tmp_path / data_file_3 / "tenant_code=demo_tenant_2" / "api_year=2000").is_dir()
-    assert (tmp_path / data_file_3 / "tenant_code=demo_tenant_2" / "api_year=2001").is_dir()
 
 def test_partition_col_names(tmp_path):
-    data_filename = 'data'
-    data_path = tmp_path / f'{data_filename}.csv'
+    # arrange: use different column names than what the function expects
+    data = pd.DataFrame(
+        {
+            "id": [i for i in range(6)],
+            "name": (["tenant"] * 3) + (["tenant_2"] * 3),
+            "data_year": (["1999"] * 2) + (["2000"] * 2) + (["2001"] * 2),
+        }
+    )
 
-    test_data_small().to_csv(data_path, index=False)
+    data_path = tmp_path / f"{DEFAULT_FILE}.csv"
+    data.to_csv(data_path, index=False)
 
-    EarthbeamDAG.partition_on_tenant_and_year(data_path, tmp_path, tenant_col="name", year_col="data_year")
+    # act: provide the alternative names
+    EarthbeamDAG.partition_on_tenant_and_year(
+        data_path, tmp_path, tenant_col="name", year_col="data_year"
+    )
 
-    assert (tmp_path / data_filename / "tenant_code=demo_tenant").is_dir()
-    assert (tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=1999").is_dir()
-    assert any((tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=1999").iterdir())
+    # assert: result should be identical
+    validate_partitions(tmp_path / DEFAULT_FILE)
 
-    assert (tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=2000").is_dir()
-    assert not (tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=2001").is_dir()
-
-    assert (tmp_path / data_filename / "tenant_code=demo_tenant_2").is_dir()
-    assert not (tmp_path / data_filename / "tenant_code=demo_tenant_2" / "api_year=1999").is_dir()
-    assert (tmp_path / data_filename / "tenant_code=demo_tenant_2" / "api_year=2000").is_dir()
-    assert (tmp_path / data_filename / "tenant_code=demo_tenant_2" / "api_year=2001").is_dir()
 
 def test_partition_col_maps(tmp_path):
-    simple_data = {
-        'id': [i for i in range(6)],
-        'tenant_code': (['dt' ] * 3) + (['dt2'] * 3),
-        'api_year': (['99'] * 2) + (['00'] * 2) + (['01'] * 2)
-    }
+    # arrange
+    data = pd.DataFrame(
+        {
+            "id": [i for i in range(6)],
+            "tenant_code": (["dt"] * 3) + (["dt2"] * 3),
+            "api_year": (["99"] * 2) + (["00"] * 2) + (["01"] * 2),
+        }
+    )
 
-    data_filename = 'data'
-    data_path = tmp_path / f'{data_filename}.csv'
+    data_path = tmp_path / f"{DEFAULT_FILE}.csv"
+    data.to_csv(data_path, index=False)
 
-    test_data_small().to_csv(data_path, index=False)
+    # act: map the above values to the desired partition names
+    EarthbeamDAG.partition_on_tenant_and_year(
+        data_path,
+        tmp_path,
+        tenant_map={"dt": "tenant", "dt2": "tenant_2"},
+        year_map={"99": "1999", "00": "2000", "01": "2001"},
+    )
 
-    EarthbeamDAG.partition_on_tenant_and_year(data_path, tmp_path, tenant_map={'dt': 'demo_tenant', 'dt2': 'demo_tenant_2'}, year_map={'99': '1999', '00': '2000', '01': '2001'})
+    # assert
+    validate_partitions(tmp_path / DEFAULT_FILE)
 
-    assert (tmp_path / data_filename / "tenant_code=demo_tenant").is_dir()
-    assert (tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=1999").is_dir()
-    assert any((tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=1999").iterdir())
-
-    assert (tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=2000").is_dir()
-    assert not (tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=2001").is_dir()
-
-    assert (tmp_path / data_filename / "tenant_code=demo_tenant_2").is_dir()
-    assert not (tmp_path / data_filename / "tenant_code=demo_tenant_2" / "api_year=1999").is_dir()
-    assert (tmp_path / data_filename / "tenant_code=demo_tenant_2" / "api_year=2000").is_dir()
-    assert (tmp_path / data_filename / "tenant_code=demo_tenant_2" / "api_year=2001").is_dir()
 
 def test_partition_col_names_and_maps(tmp_path):
-    data_filename = 'data'
-    data_path = tmp_path / f'{data_filename}.csv'
+    # arrange
+    data = pd.DataFrame(
+        {
+            "id": [i for i in range(6)],
+            "name": (["t"] * 3) + (["t2"] * 3),
+            "data_year": (["99"] * 2) + (["00"] * 2) + (["01"] * 2),
+        }
+    )
 
-    test_data_small().to_csv(data_path, index=False)
+    data_path = tmp_path / f"{DEFAULT_FILE}.csv"
+    data.to_csv(data_path, index=False)
 
-    EarthbeamDAG.partition_on_tenant_and_year(data_path, tmp_path, tenant_col="name", tenant_map={'dt': 'demo_tenant', 'dt2': 'demo_tenant_2'}, year_col="data_year", year_map={'99': '1999', '00': '2000', '01': '2001'})
+    # act
+    EarthbeamDAG.partition_on_tenant_and_year(
+        data_path,
+        tmp_path,
+        tenant_col="name",
+        tenant_map={"t": "tenant", "t2": "tenant_2"},
+        year_col="data_year",
+        year_map={"99": "1999", "00": "2000", "01": "2001"},
+    )
 
-    assert (tmp_path / data_filename / "tenant_code=demo_tenant").is_dir()
-    assert (tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=1999").is_dir()
-    assert any((tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=1999").iterdir())
-
-    assert (tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=2000").is_dir()
-    assert not (tmp_path / data_filename / "tenant_code=demo_tenant" / "api_year=2001").is_dir()
-
-    assert (tmp_path / data_filename / "tenant_code=demo_tenant_2").is_dir()
-    assert not (tmp_path / data_filename / "tenant_code=demo_tenant_2" / "api_year=1999").is_dir()
-    assert (tmp_path / data_filename / "tenant_code=demo_tenant_2" / "api_year=2000").is_dir()
-    assert (tmp_path / data_filename / "tenant_code=demo_tenant_2" / "api_year=2001").is_dir()
+    # assert
+    validate_partitions(tmp_path / DEFAULT_FILE)
 
 
 def test_record_in_correct_partition(tmp_path):
-    simple_data = {
-        'id': [i for i in range(6000000)],
-        'tenant_code': (['demo_tenant' ] * 3000000) + ['special_tenant'] + (['demo_tenant_2'] * 2999999),
-        'api_year': (['1999'] * 2000000) + (['2000'] * 2000000) + (['2001'] * 2000000)
-    }
+    # arrange: large dataframe with a partition containing a single record
+    tenant_codes = (["tenant"] * 3000000) + ["special"] + (["tenant_2"] * 2999999)
+    api_years = (["1999"] * 2000000) + (["2000"] * 2000000) + (["2001"] * 2000000)
+    data = pd.DataFrame(
+        {
+            "id": [i for i in range(6000000)],
+            "tenant_code": tenant_codes,
+            "api_year": api_years,
+        }
+    )
 
-    data_filename = 'data'
-    data_path = tmp_path / f'{data_filename}.csv'
+    data_path = tmp_path / f"{DEFAULT_FILE}.csv"
+    data.to_csv(data_path, index=False)
 
-    pd.DataFrame(simple_data).to_csv(data_path, index=False)
-
+    # act
     EarthbeamDAG.partition_on_tenant_and_year(data_path, tmp_path)
 
-    df = pd.read_parquet(tmp_path / data_filename / 'tenant_code=special_tenant') 
+    # assert
+    df = pd.read_parquet(tmp_path / DEFAULT_FILE / "tenant_code=special")
 
     assert len(df.index) == 1
-    assert df.loc[df.index[0], 'id'] == '3000000'
+    assert df.loc[df.index[0], "id"] == "3000000"
 
-def test_partition_invalid_csv(tmp_path):
-    data_filename = 'data'
 
-    # function expects all inputs to be CSVs
-    data_path = tmp_path / f'{data_filename}.yar'
+def test_partition_invalid_csv(tmp_path, basic_data):
+    # arrange
+    data_path = tmp_path / f"{DEFAULT_FILE}.yar"
+    basic_data.to_csv(data_path, index=False)
 
-    test_data_small().to_csv(data_path, index=False)
-
+    # assert: expect an error
     with pytest.raises(ValueError):
+        # act: the function expects all inputs to be CSVs
         EarthbeamDAG.partition_on_tenant_and_year(data_path, tmp_path)
 
-def test_partition_invalid_col(tmp_path):
-    data_filename = 'data'
-    data_path = tmp_path / f'{data_filename}.csv'
 
-    test_data_small().to_csv(data_path, index=False)
+def test_partition_invalid_col(tmp_path, basic_data):
+    # arrange
+    data_path = tmp_path / f"{DEFAULT_FILE}.csv"
+    basic_data.to_csv(data_path, index=False)
 
+    # assert: expect error
     with pytest.raises(KeyError):
-        EarthbeamDAG.partition_on_tenant_and_year(data_path, tmp_path, tenant_col='not_found')
+        # act: the function will fail to use this column
+        EarthbeamDAG.partition_on_tenant_and_year(
+            data_path, tmp_path, tenant_col="not_found"
+        )


### PR DESCRIPTION
Pertains to [this ticket](https://educationanalytics.monday.com/boards/3556827529/pulses/6758448915)

Add a static method to the `EarthbeamDAG` class that takes in one or more CSVs and saves them as parquet files partitioned by `tenant_code` and `api_year` (or equivalent columns)

### Testing

The easiest way to test this code is by running the included unit tests. Since there was no existing test framework attached to this repo, I took the liberty of initializing some Pytest configuration. In order to run the tests, do the following:
  - In a virtual environment, run `pip install -r requirements-dev.txt`
  - This will likely fail because of the dependencies on non-public packages edfi_api_client and ea_airflow_util. You will need to install these locally for the environment to be complete
    - This is annoying locally, but would not be an issue in an automated environment -- if we ran the unit tests as part of a Github action, we would have access to the necessary repos
  - Running `pytest` is sufficient to run the entire suite. For more detail, you can run `pytest -v`

The test file serves as documentation for how the new function can be used.