### PR TITLE
Copy query_parameters when called in build_endpoint_configs to preven…

### DIFF
--- a/edu_edfi_airflow/dags/edfi_resource_dag.py
+++ b/edu_edfi_airflow/dags/edfi_resource_dag.py
@@ -1,3 +1,4 @@
+import copy
 import os
 from functools import partial
 from typing import Dict, List, Optional, Set, Tuple, Union
@@ -144,6 +145,7 @@ class EdFiResourceDAG:
         `enabled` and `fetch_deletes` are not passed into configs.
         """
         configs = {**self.DEFAULT_CONFIGS, **kwargs}
+        configs["query_parameters"] = copy.deepcopy(configs["query_parameters"])  # Prevent query_parameters from being shared across DAGs.
 
         ### For a multiyear ODS, we need to specify school year as an additional query parameter.
         # (This is an exception-case; we push all tenants to build year-specific ODSes when possible.)


### PR DESCRIPTION
…t desynchronization across DAG runs.

This bug was caused by `query_parameters` being updated in place. If `school_year` was set to true for any DAG, this parameter remained in the argument and cascaded into all subsequent DAGs. To resolve this, the contents of `query_parameters` has been deep-copied before being set in the endpoint configs.