### PR TITLE
Feature/earthbeam student ID package

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ Task-groups can also apply an optional Python preprocessing callable to the raw 
 | full_refresh                 | Boolean flag to run a full truncate-replace of the warehouse data for the given grain if copying data directly into the ODS    |
 | assessment_bundle            | Optional (required for student ID xwalking) name of the assessment bundle being run                                            |
 | student_id_match_rates_table | Optional (required for student ID xwalking) Snowflake table set up for storing student ID match rates (db.schema.table)        |
-| snowflake_read_conn_id       | Optional (required for student ID xwalking) Airflow with Snowflake credentials for reading from the `analytics` database       |
+| snowflake_read_conn_id       | Optional (required for student ID xwalking) Airflow connectionwith Snowflake credentials for reading from the `analytics` db   |
 | required_id_match_rate       | Optional float value for minimum student ID match rate, otherwise EM will fail                                                 |
 
 -----

--- a/README.md
+++ b/README.md
@@ -459,27 +459,32 @@ Task-groups can also apply an optional Python preprocessing callable to the raw 
 <details>
 <summary>Taskgroup-level Arguments:</summary>
 
-| Argument           | Description                                                                                                                    |
-|:-------------------|:-------------------------------------------------------------------------------------------------------------------------------|
-| tenant_code        | ODS-tenant representation to be saved in Snowflake tables                                                                      |
-| api_year           | ODS API-year to be saved in Snowflake tables                                                                                   |
-| raw_dir            | Path to the directory on the EC2 server where pre-Earthmover data is found                                                     |
-| grain_update       | Optional string to extend the grain of the task-group beyond (tenant, year)                                                    |
-| group_id           | Optional static string-representation of the task-group (a generated name is used if undefined)                                |
-| prefix_group_id    | Optional boolean flag for whether to prefix the name of task-group operators with the `group_id` (default False)               |
-| earthmover_kwargs  | Kwarg command-line arguments to be passed into `EarthmoverOperator`                                                            |
-| edfi_conn_id       | Airflow connection with Ed-Fi ODS credentials and metadata defined for a specific tenant                                       |
-| lightbeam_kwargs   | Kwarg command-line arguments to be passed into `LightbeamOperator`                                                             |
-| s3_conn_id         | Airflow connection with S3 bucket defined under `schema`                                                                       |
-| s3_filepath        | S3 root key to copy staging data to before and after running Earthmover                                                        |
-| python_callable    | Optional Python callable to run at the start of the task-group prior to Earthmover                                             |
-| python_kwargs      | Optional kwargs to pass into `python_callable`                                                                                 |
-| snowflake_conn_id  | Optional Airflow connection with Snowflake credentials, database, and schema defined                                           |
-| logging_table      | Optional name of a table to record Earthmover and Lightbeam results to in Snowflake                                            |
-| ods_version        | Optional Ed-Fi ODS version to save as metadata if copying data directly into the ODS                                           |
-| data_model_version | Optional Ed-Fi data model version to save as metadata if copying data directly into the ODS                                    |
-| endpoints          | Optional list of resource/descriptor endpoints to copy data directly into the ODS (these should align with Earthmover outputs) |
-| full_refresh       | Boolean flag to run a full truncate-replace of the warehouse data for the given grain if copying data directly into the ODS    |
+| Argument                     | Description                                                                                                                    |
+|:-----------------------------|:-------------------------------------------------------------------------------------------------------------------------------|
+| tenant_code                  | ODS-tenant representation to be saved in Snowflake tables                                                                      |
+| api_year                     | ODS API-year to be saved in Snowflake tables                                                                                   |
+| raw_dir                      | Path to the directory on the EC2 server where pre-Earthmover data is found                                                     |
+| grain_update                 | Optional string to extend the grain of the task-group beyond (tenant, year)                                                    |
+| group_id                     | Optional static string-representation of the task-group (a generated name is used if undefined)                                |
+| prefix_group_id              | Optional boolean flag for whether to prefix the name of task-group operators with the `group_id` (default False)               |
+| earthmover_kwargs            | Kwarg command-line arguments to be passed into `EarthmoverOperator`                                                            |
+| edfi_conn_id                 | Airflow connection with Ed-Fi ODS credentials and metadata defined for a specific tenant                                       |
+| lightbeam_kwargs             | Kwarg command-line arguments to be passed into `LightbeamOperator`                                                             |
+| s3_conn_id                   | Airflow connection with S3 bucket defined under `schema`                                                                       |
+| s3_filepath                  | S3 root key to copy staging data to before and after running Earthmover                                                        |
+| python_callable              | Optional Python callable to run at the start of the task-group prior to Earthmover                                             |
+| python_kwargs                | Optional kwargs to pass into `python_callable`                                                                                 |
+| python_postprocess_callable  | Optional Python callable to run at the end of the task-group                                                                   |
+| python_postprocess_kwargs    | Optional kwargs to pass into `python_postprocess_callable`                                                                     |
+| snowflake_conn_id            | Optional Airflow connection with Snowflake credentials, database, and schema defined                                           |
+| logging_table                | Optional name of a table to record Earthmover and Lightbeam results to in Snowflake                                            |
+| ods_version                  | Optional Ed-Fi ODS version to save as metadata if copying data directly into the ODS                                           |
+| data_model_version           | Optional Ed-Fi data model version to save as metadata if copying data directly into the ODS                                    |
+| endpoints                    | Optional list of resource/descriptor endpoints to copy data directly into the ODS (these should align with Earthmover outputs) |
+| full_refresh                 | Boolean flag to run a full truncate-replace of the warehouse data for the given grain if copying data directly into the ODS    |
+| assessment_bundle            | Optional (required for student ID xwalking) name of the assessment bundle being run                                            |
+| student_id_match_rates_table | Optional (required for student ID xwalking) Snowflake table set up for storing student ID match rates (db.schema.table)        |
+| required_id_match_rate       | Optional float value for minimum student ID match rate, otherwise EM will fail                                                 |
 
 -----
 

--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ Task-groups can also apply an optional Python preprocessing callable to the raw 
 | python_kwargs                | Optional kwargs to pass into `python_callable`                                                                                 |
 | python_postprocess_callable  | Optional Python callable to run at the end of the task-group                                                                   |
 | python_postprocess_kwargs    | Optional kwargs to pass into `python_postprocess_callable`                                                                     |
-| snowflake_conn_id            | Optional Airflow connection with Snowflake credentials, database, and schema defined                                           |
+| snowflake_conn_id            | Optional Airflow connection with Snowflake credentials, database, and schema defined, used for loading to raw                  |
 | logging_table                | Optional name of a table to record Earthmover and Lightbeam results to in Snowflake                                            |
 | ods_version                  | Optional Ed-Fi ODS version to save as metadata if copying data directly into the ODS                                           |
 | data_model_version           | Optional Ed-Fi data model version to save as metadata if copying data directly into the ODS                                    |
@@ -484,6 +484,7 @@ Task-groups can also apply an optional Python preprocessing callable to the raw 
 | full_refresh                 | Boolean flag to run a full truncate-replace of the warehouse data for the given grain if copying data directly into the ODS    |
 | assessment_bundle            | Optional (required for student ID xwalking) name of the assessment bundle being run                                            |
 | student_id_match_rates_table | Optional (required for student ID xwalking) Snowflake table set up for storing student ID match rates (db.schema.table)        |
+| snowflake_read_conn_id       | Optional (required for student ID xwalking) Airflow with Snowflake credentials for reading from the `analytics` database       |
 | required_id_match_rate       | Optional float value for minimum student ID match rate, otherwise EM will fail                                                 |
 
 -----

--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ Task-groups can also apply an optional Python preprocessing callable to the raw 
 | full_refresh                 | Boolean flag to run a full truncate-replace of the warehouse data for the given grain if copying data directly into the ODS    |
 | assessment_bundle            | Optional (required for student ID xwalking) name of the assessment bundle being run                                            |
 | student_id_match_rates_table | Optional (required for student ID xwalking) Snowflake table set up for storing student ID match rates (db.schema.table)        |
-| snowflake_read_conn_id       | Optional (required for student ID xwalking) Airflow connectionwith Snowflake credentials for reading from the `analytics` db   |
+| snowflake_read_conn_id       | Optional (required for student ID xwalking) Airflow connection with Snowflake credentials for reading from the `analytics` db  |
 | required_id_match_rate       | Optional float value for minimum student ID match rate, otherwise EM will fail                                                 |
 
 -----

--- a/README.md
+++ b/README.md
@@ -475,7 +475,7 @@ Task-groups can also apply an optional Python preprocessing callable to the raw 
 | python_callable              | Optional Python callable to run at the start of the task-group prior to Earthmover                                             |
 | python_kwargs                | Optional kwargs to pass into `python_callable`                                                                                 |
 | python_postprocess_callable  | Optional Python callable to run at the end of the task-group                                                                   |
-| python_postprocess_kwargs    | Optional kwargs to pass into `python_postprocess_callable`                                                                     |
+| python_postprocess_kwargs    | Optional kwargs to pass into `python_postprocess_callable`. Kwargs `em_data_dir` and `em_s3_filepath` will also be passed      |
 | snowflake_conn_id            | Optional Airflow connection with Snowflake credentials, database, and schema defined, used for loading to raw                  |
 | logging_table                | Optional name of a table to record Earthmover and Lightbeam results to in Snowflake                                            |
 | ods_version                  | Optional Ed-Fi ODS version to save as metadata if copying data directly into the ODS                                           |

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -175,7 +175,7 @@ class EarthbeamDAG:
     def build_tenant_year_taskgroup(self,
         tenant_code: str,
         api_year: int,
-        raw_dir: str,
+        raw_dir: str,  # TODO: What role does raw_dir serve? Why was it even here when I first developed this?
 
         *,
         grain_update: Optional[str] = None,
@@ -304,7 +304,10 @@ class EarthbeamDAG:
                 data_model_version=data_model_version,
                 endpoints=endpoints,
                 full_refresh=full_refresh,
-            )(input_file_envs=input_file_mapping.keys(), input_filepaths=input_file_mapping.values())
+            )(
+                input_file_envs=input_file_mapping.keys(),
+                input_filepaths=input_file_mapping.values()
+            )
             task_order.append(em_task_group)
 
         # Chain all defined operators into task-order.

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -589,6 +589,8 @@ class EarthbeamDAG:
                         local_filepath=filepath,
                         remove_local_filepath=False
                     )
+
+                return s3_full_filepath
             
             @task
             def log_to_snowflake(results_filepath: str, **context):

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -9,6 +9,7 @@ from airflow.exceptions import AirflowFailException, AirflowSkipException
 from airflow.models.param import Param
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator
+from airflow.operators.python import get_current_context
 from airflow.utils.helpers import chain
 from airflow.utils.task_group import TaskGroup
 
@@ -953,10 +954,12 @@ class EarthbeamDAG:
             }
         
         @task
-        def em_to_snowflake(s3_destination_dir: str, endpoint: str, **context):
+        def em_to_snowflake(s3_destination_dir: str, endpoint: str):
             # Snowflake tables are snake_cased; Earthmover outputs are camelCased
             snake_endpoint = edfi_api_client.camel_to_snake(endpoint)
             camel_endpoint = edfi_api_client.snake_to_camel(endpoint)
+
+            context = get_current_context()  # Retrieve context manually to exclude conf.
 
             # Descriptors have their own table
             if 'descriptor' in snake_endpoint:

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -296,7 +296,7 @@ class EarthbeamDAG:
                     and key.lower() != "input_filetype"
                 }
 
-            em_task_group = self.file_to_edfi_taskgroup(
+            em_task_group = self.file_to_edfi_taskgroup.override(dag=self.dag)(
                 input_file_mapping=input_file_mapping,
 
                 tenant_code=tenant_code,
@@ -475,7 +475,7 @@ class EarthbeamDAG:
                 )
                 list_files_task >> failed_sentinel
 
-            em_task_group = self.file_to_edfi_taskgroup.partial(
+            em_task_group = self.file_to_edfi_taskgroup.override(dag=self.dag).partial(
                 tenant_code=tenant_code,
                 api_year=api_year,
                 grain_update=grain_update,

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -622,7 +622,7 @@ class EarthbeamDAG:
 
         **kwargs
     ):
-        @task
+        @task(dag=self.dag)
         def upload_to_s3(filepath: str, subdirectory: str, **context):
             if not s3_filepath:
                 raise ValueError(
@@ -645,7 +645,7 @@ class EarthbeamDAG:
                 remove_local_filepath=False
             )
         
-        @task
+        @task(dag=self.dag)
         def log_to_snowflake(results_filepath: str, **context):
             return self.insert_earthbeam_result_to_logging_table(
                 snowflake_conn_id=snowflake_conn_id,
@@ -657,7 +657,7 @@ class EarthbeamDAG:
                 **context
             )
         
-        @task(multiple_outputs=True)
+        @task(multiple_outputs=True, dag=self.dag)
         def run_earthmover(env_mapping: dict, **context):
             file_basename = self.get_filename(env_mapping.values()[0])
             
@@ -701,7 +701,7 @@ class EarthbeamDAG:
                 "results_file": em_results_file,
             }
         
-        @task(multiple_outputs=True)
+        @task(multiple_outputs=True, dag=self.dag)
         def run_lightbeam(data_dir: str, **context):
             dir_basename = self.get_filename(data_dir)
 
@@ -737,7 +737,7 @@ class EarthbeamDAG:
                 "results_file": lb_results_file,
             }
         
-        @task
+        @task(dag=self.dag)
         def em_to_snowflake(s3_destination_dir: str, endpoint: str, **context):
             # Snowflake tables are snake_cased; Earthmover outputs are camelCased
             snake_endpoint = edfi_api_client.camel_to_snake(endpoint)

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -582,7 +582,7 @@ class EarthbeamDAG:
         return os.path.splitext(os.path.basename(filepath))[0]
 
     @task_group(prefix_group_id=True, group_id="file_to_earthbeam")
-    def file_to_edfi_taskgroup_tasks(self,
+    def file_to_edfi_taskgroup(self,
         input_file_mapping: dict,
 
         *,

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -583,6 +583,7 @@ class EarthbeamDAG:
     def get_filename(filepath: str) -> str:
         return os.path.splitext(os.path.basename(filepath))[0]
 
+    @staticmethod
     @task_group(prefix_group_id=True, group_id="file_to_earthbeam")
     def file_to_edfi_taskgroup(self,
         input_file_mapping: dict,

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -858,7 +858,7 @@ class EarthbeamDAG:
                 s3_destination_key=s3_full_filepath,
                 local_filepath=filepath,
                 remove_local_filepath=False,
-                **{key: val for key, val in context if key != 'conf'}  # TODO: Why is this necessary?
+                **{key: val for key, val in context.items() if key != 'conf'}  # TODO: Why is this necessary?
             )
         
         @task

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -1030,8 +1030,8 @@ class EarthbeamDAG:
 
             # Raw to S3
             if s3_conn_id:
-                upload_to_s3.override(task_id=f"upload_raw_to_s3")(input_filepaths, "raw")
-                all_tasks.append(upload_to_s3)
+                raw_to_s3 = upload_to_s3.override(task_id=f"upload_raw_to_s3")(input_filepaths, "raw")
+                all_tasks.append(raw_to_s3)
             else:
                 raw_to_s3 = None
 

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -331,7 +331,7 @@ class EarthbeamDAG:
             # Chain all defined operators into task-order.
             chain(*task_order)
 
-        return tenant_year_task_group
+            return tenant_year_task_group
 
 
     ### Dynamic Earthbeam across multiple files

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -1030,9 +1030,10 @@ class EarthbeamDAG:
 
             # Raw to S3
             if s3_conn_id:
-<<<<<<< HEAD
                 upload_to_s3.override(task_id=f"upload_raw_to_s3")(input_filepaths, "raw")
                 all_tasks.append(upload_to_s3)
+            else:
+                raw_to_s3 = None
 
             # Pull stored student ID match rates and run earthmover
             if student_id_match_rates_table:
@@ -1042,13 +1043,9 @@ class EarthbeamDAG:
             else:
                 earthmover_results = run_earthmover(input_file_envs, input_filepaths)
             
-=======
                 raw_to_s3 = upload_to_s3.override(task_id=f"upload_raw_to_s3")(input_filepaths, "raw")
                 all_tasks.append(raw_to_s3)
-            else:
-                raw_to_s3 = None
                 
->>>>>>> rc/0.4.0
             # EarthmoverOperator: Required
             all_tasks.append(earthmover_results)
             paths_to_clean.append(earthmover_results["data_dir"])

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -579,7 +579,8 @@ class EarthbeamDAG:
                 )
                 s3_full_filepath = context['task'].render_template(s3_full_filepath, context)
 
-                for filepath in list(filepaths):
+                filepaths = [filepaths] if isinstance(filepaths, str) else filepaths
+                for filepath in filepaths:
                     filepath = context['task'].render_template(filepath, context)
 
                     local_filepath_to_s3(
@@ -603,9 +604,9 @@ class EarthbeamDAG:
             
             @task(multiple_outputs=True)
             def run_earthmover(input_file_envs: Union[str, List[str]], input_filepaths: Union[str, List[str]], **context):
-                input_file_envs = list(input_file_envs)
-                input_filepaths = list(input_filepaths)
-                
+                input_file_envs = [input_file_envs] if isinstance(input_file_envs, str) else input_file_envs
+                input_filepaths = [input_filepaths] if isinstance(input_filepaths, str) else input_filepaths
+
                 file_basename = self.get_filename(input_filepaths[0])
                 env_mapping = dict(zip(input_file_envs, input_filepaths))
                 

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -297,7 +297,6 @@ class EarthbeamDAG:
                 }
 
             em_task_group = self.file_to_edfi_taskgroup.override(dag=self.dag)(
-                self,
                 input_file_mapping=input_file_mapping,
 
                 tenant_code=tenant_code,
@@ -477,7 +476,6 @@ class EarthbeamDAG:
                 list_files_task >> failed_sentinel
 
             em_task_group = self.file_to_edfi_taskgroup.override(dag=self.dag).partial(
-                self,
                 tenant_code=tenant_code,
                 api_year=api_year,
                 grain_update=grain_update,
@@ -583,7 +581,6 @@ class EarthbeamDAG:
     def get_filename(filepath: str) -> str:
         return os.path.splitext(os.path.basename(filepath))[0]
 
-    @staticmethod
     @task_group(prefix_group_id=True, group_id="file_to_earthbeam")
     def file_to_edfi_taskgroup(self,
         input_file_mapping: dict,

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -946,7 +946,7 @@ class EarthbeamDAG:
                 for endpoint in endpoints:
                     em_to_snowflake.override(task_id=f"copy_s3_to_snowflake__{endpoint}")(s3_destination_dir, endpoint)
 
-            @task (dag=self.dag)
+            @task(dag=self.dag)
             def match_rates_to_snowflake(s3_full_filepath:str):
                 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
 
@@ -985,9 +985,9 @@ class EarthbeamDAG:
 
                 return
 
-            @task_group(prefix_group_id=True, dag=self.dag)
-            def run_python_postprocess(python_postprocess_callable: Callable, python_postprocess_kwargs: dict, **context):
-                python_postprocess = python_postprocess_callable(python_postprocess_kwargs, **context)
+            @task(dag=self.dag)
+            def run_python_postprocess(python_postprocess_callable: Callable, python_postprocess_kwargs: dict, em_data_dir: str, em_s3_filepath: Optional[str], **context):
+                python_postprocess = python_postprocess_callable(**python_postprocess_kwargs, em_data_dir=em_data_dir, em_s3_filepath=em_s3_filepath, **context)
                 return python_postprocess
 
             @task(trigger_rule="all_done" if self.fast_cleanup else "all_success", dag=self.dag)
@@ -1067,7 +1067,10 @@ class EarthbeamDAG:
                     all_tasks.append(log_lb_to_snowflake)
 
             if python_postprocess_callable:
-                python_postprocess = run_python_postprocess(python_postprocess_callable, python_postprocess_kwargs)
+                if em_s3_filepath:
+                    python_postprocess = run_python_postprocess(python_postprocess_callable, python_postprocess_kwargs, em_data_dir=earthmover_results["data_dir"], em_s3_filepath=em_s3_filepath)
+                else: 
+                    python_postprocess = run_python_postprocess(python_postprocess_callable, python_postprocess_kwargs, em_data_dir=earthmover_results["data_dir"])
                 all_tasks.append(python_postprocess)
 
             # Final cleanup (apply at very end of the taskgroup)

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -297,6 +297,7 @@ class EarthbeamDAG:
                 }
 
             em_task_group = self.file_to_edfi_taskgroup.override(dag=self.dag)(
+                self,
                 input_file_mapping=input_file_mapping,
 
                 tenant_code=tenant_code,
@@ -476,6 +477,7 @@ class EarthbeamDAG:
                 list_files_task >> failed_sentinel
 
             em_task_group = self.file_to_edfi_taskgroup.override(dag=self.dag).partial(
+                self,
                 tenant_code=tenant_code,
                 api_year=api_year,
                 grain_update=grain_update,

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -579,10 +579,7 @@ class EarthbeamDAG:
                 )
                 s3_full_filepath = context['task'].render_template(s3_full_filepath, context)
 
-                if isinstance(filepaths, str):
-                    filepaths = [filepaths]
-
-                for filepath in filepaths:
+                for filepath in list(filepaths):
                     filepath = context['task'].render_template(filepath, context)
 
                     local_filepath_to_s3(
@@ -605,8 +602,11 @@ class EarthbeamDAG:
                 )
             
             @task(multiple_outputs=True)
-            def run_earthmover(**context):
+            def run_earthmover(input_file_envs: Union[str, List[str]], input_filepaths: Union[str, List[str]], **context):
+                input_file_envs = list(input_file_envs)
+                input_filepaths = list(input_filepaths)
                 env_mapping = dict(zip(input_file_envs, input_filepaths))
+                
                 file_basename = self.get_filename(env_mapping.values()[0])
                 
                 em_output_dir = edfi_api_client.url_join(
@@ -753,7 +753,7 @@ class EarthbeamDAG:
                 all_tasks.append(upload_to_s3)
                 
             # EarthmoverOperator: Required
-            earthmover_results = run_earthmover()
+            earthmover_results = run_earthmover(input_file_envs, input_filepaths)
             all_tasks.append(earthmover_results)
             paths_to_clean.append(earthmover_results["data_dir"])
 

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -328,10 +328,9 @@ class EarthbeamDAG:
             em_task_group = file_to_edfi_taskgroup(input_file_mapping)
             task_order.append(em_task_group)
 
-            # Chain all defined operators into task-order.
-            chain(*task_order)
-
-            return tenant_year_task_group
+        # Chain all defined operators into task-order.
+        chain(*task_order)
+        return tenant_year_task_group
 
 
     ### Dynamic Earthbeam across multiple files
@@ -515,10 +514,9 @@ class EarthbeamDAG:
             em_task_group = file_to_edfi_taskgroup.expand(filepath=list_files_task.output)
             task_order.append(em_task_group)
 
-            # Chain all defined operators into task-order.
-            chain(*task_order)
-
-            return dynamic_tenant_year_task_group
+        # Chain all defined operators into task-order.
+        chain(*task_order)
+        return dynamic_tenant_year_task_group
 
 
     def insert_earthbeam_result_to_logging_table(self,

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -1019,9 +1019,6 @@ class EarthbeamDAG:
                 earthmover_results = run_earthmover(input_file_envs, input_filepaths, max_match_rate)
             else:
                 earthmover_results = run_earthmover(input_file_envs, input_filepaths)
-            
-                raw_to_s3 = upload_to_s3.override(task_id=f"upload_raw_to_s3")(input_filepaths, "raw")
-                all_tasks.append(raw_to_s3)
                 
             # EarthmoverOperator: Required
             all_tasks.append(earthmover_results)

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -858,7 +858,7 @@ class EarthbeamDAG:
                 s3_destination_key=s3_full_filepath,
                 local_filepath=filepath,
                 remove_local_filepath=False,
-                **context
+                **{key: val for key, val in context if key != 'conf'}  # TODO: Why is this necessary?
             )
         
         @task

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -9,7 +9,6 @@ from airflow.exceptions import AirflowFailException, AirflowSkipException
 from airflow.models.param import Param
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator
-from airflow.operators.python import get_current_context
 from airflow.utils.helpers import chain
 from airflow.utils.task_group import TaskGroup
 
@@ -859,7 +858,7 @@ class EarthbeamDAG:
                 s3_destination_key=s3_full_filepath,
                 local_filepath=filepath,
                 remove_local_filepath=False,
-                **get_current_context()
+                **context
             )
         
         @task

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -807,9 +807,11 @@ class EarthbeamDAG:
                         env_mapping.update({
                             'EDFI_ROSTER_SOURCE_TYPE': 'snowflake',
                             'SNOWFLAKE_EDU_STG_SCHEMA': 'analytics.prod_stage',
-                            'SNOWFLAKE_TENANT_CODE': tenant_code,
-                            'SNOWFLAKE_API_YEAR': api_year
+                            'SNOWFLAKE_TENANT_CODE': tenant_code
                         })
+                        # Don't overwrite if this was provided as an earthmover param (used for loading historical files using a current year of roster data)
+                        if 'SNOWFLAKE_API_YEAR' not in env_mapping:
+                            env_mapping['SNOWFLAKE_API_YEAR'] = api_year
 
                     # Add params for querying existing match rates if a high enough match has previously been found
                     if max_match_rate is not None and max_match_rate >= required_id_match_rate:

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -458,8 +458,8 @@ class EarthbeamDAG:
                 endpoints=endpoints,
                 full_refresh=full_refresh,
             )(
-                input_file_envs=input_file_mapping.keys(),
-                input_filepaths=input_file_mapping.values()
+                input_file_envs=list(input_file_mapping.keys()),
+                input_filepaths=list(input_file_mapping.values())
             )
             task_order.append(em_task_group)
 
@@ -788,10 +788,10 @@ class EarthbeamDAG:
             
             @task(dag=self.dag)
             def log_to_snowflake(results_filepath: str, **context):
-                return self.insert_earthbeam_result_to_logging_table(
+                return self.log_to_snowflake(
                     snowflake_conn_id=snowflake_conn_id,
                     logging_table=logging_table,
-                    results_filepath=results_filepath,
+                    log_filepath=results_filepath,
                     tenant_code=tenant_code,
                     api_year=api_year,
                     grain_update=grain_update,

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -605,9 +605,9 @@ class EarthbeamDAG:
             def run_earthmover(input_file_envs: Union[str, List[str]], input_filepaths: Union[str, List[str]], **context):
                 input_file_envs = list(input_file_envs)
                 input_filepaths = list(input_filepaths)
-                env_mapping = dict(zip(input_file_envs, input_filepaths))
                 
-                file_basename = self.get_filename(list(env_mapping.values())[0])
+                file_basename = self.get_filename(input_filepaths[0])
+                env_mapping = dict(zip(input_file_envs, input_filepaths))
                 
                 em_output_dir = edfi_api_client.url_join(
                     self.em_output_directory,

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -252,9 +252,7 @@ class EarthbeamDAG:
         grain_update: Optional[str] = None,
         group_id: Optional[str] = None,
 
-        database_conn_id: Optional[str] = None,
         earthmover_kwargs: Optional[dict] = None,
-
         edfi_conn_id: Optional[str] = None,
         lightbeam_kwargs: Optional[dict] = None,
 
@@ -277,6 +275,7 @@ class EarthbeamDAG:
 
         assessment_bundle: Optional[str] = None,
         student_id_match_rates_table: Optional[str] = None,
+        snowflake_read_conn_id: Optional[str] = None,
         required_id_match_rate: Optional[float] = 0.5,
 
         # Mapping of input environment variables to be injected into the taskgroup.
@@ -304,9 +303,7 @@ class EarthbeamDAG:
         :param grain_update:
         :param group_id:
 
-        :param database_conn_id:
         :param earthmover_kwargs:
-
         :param edfi_conn_id:
         :param lightbeam_kwargs:
 
@@ -329,6 +326,7 @@ class EarthbeamDAG:
 
         :param assessment_bundle:
         :param student_id_match_rates_table:
+        :param snowflake_read_conn_id:
         :param required_id_match_rate:
 
         :param input_file_mapping:
@@ -390,9 +388,7 @@ class EarthbeamDAG:
                 api_year=api_year,
                 grain_update=grain_update,
 
-                database_conn_id=database_conn_id,
                 earthmover_kwargs=earthmover_kwargs,
-
                 edfi_conn_id=edfi_conn_id,
                 lightbeam_kwargs=lightbeam_kwargs,
 
@@ -405,14 +401,16 @@ class EarthbeamDAG:
                 snowflake_conn_id=snowflake_conn_id,
                 logging_table=logging_table,
 
-                assessment_bundle=assessment_bundle,
-                student_id_match_rates_table=student_id_match_rates_table,
-                required_id_match_rate=required_id_match_rate,          
-
                 ods_version=ods_version,
                 data_model_version=data_model_version,
                 endpoints=endpoints,
                 full_refresh=full_refresh,
+
+                assessment_bundle=assessment_bundle,
+                student_id_match_rates_table=student_id_match_rates_table,
+                snowflake_read_conn_id=snowflake_read_conn_id,
+                required_id_match_rate=required_id_match_rate, 
+
             )(
                 input_file_envs=list(input_file_mapping.keys()),
                 input_filepaths=list(input_file_mapping.values())
@@ -434,9 +432,7 @@ class EarthbeamDAG:
         grain_update: Optional[str] = None,
         group_id: Optional[str] = None,
 
-        database_conn_id: Optional[str] = None,
         earthmover_kwargs: Optional[dict] = None,
-
         edfi_conn_id: Optional[str] = None,
         validate_edfi_conn_id: Optional[str] = None,
         lightbeam_kwargs: Optional[dict] = None,
@@ -463,6 +459,7 @@ class EarthbeamDAG:
 
         assessment_bundle: Optional[str] = None,
         student_id_match_rates_table: Optional[str] = None,
+        snowflake_read_conn_id: Optional[str] = None,
         required_id_match_rate: Optional[float] = 0.5,
 
         # Allows overwrite of expected environment variable.
@@ -548,9 +545,7 @@ class EarthbeamDAG:
                 api_year=api_year,
                 grain_update=grain_update,
 
-                database_conn_id=database_conn_id,
                 earthmover_kwargs=earthmover_kwargs,
-
                 edfi_conn_id=edfi_conn_id,
                 validate_edfi_conn_id=validate_edfi_conn_id,
                 lightbeam_kwargs=lightbeam_kwargs,
@@ -566,6 +561,7 @@ class EarthbeamDAG:
 
                 assessment_bundle=assessment_bundle,
                 student_id_match_rates_table=student_id_match_rates_table,
+                snowflake_read_conn_id=snowflake_read_conn_id,
                 required_id_match_rate=required_id_match_rate,
 
                 ods_version=ods_version,
@@ -692,6 +688,7 @@ class EarthbeamDAG:
                         AND api_year = {api_year}
                         AND assessment_name = $${assessment_bundle}$$
                     ORDER BY match_rate desc
+                    LIMIT 1
                 """
         return qry_match_rates
 
@@ -701,9 +698,7 @@ class EarthbeamDAG:
         api_year: int,
         grain_update: Optional[str] = None,
 
-        database_conn_id: Optional[str] = None,
         earthmover_kwargs: Optional[dict] = None,
-
         edfi_conn_id: Optional[str] = None,
         validate_edfi_conn_id: Optional[str] = None,
         lightbeam_kwargs: Optional[dict] = None,
@@ -719,6 +714,7 @@ class EarthbeamDAG:
 
         assessment_bundle: Optional[str] = None,
         student_id_match_rates_table: Optional[str] = None,
+        snowflake_read_conn_id: Optional[str] = None,
         required_id_match_rate: Optional[float] = 0.5,
 
         ods_version: Optional[str] = None,
@@ -849,7 +845,7 @@ class EarthbeamDAG:
                     earthmover_path=self.earthmover_path,
                     output_dir=em_output_dir,
                     state_file=em_state_file,
-                    database_conn_id=database_conn_id,
+                    snowflake_read_conn_id=snowflake_read_conn_id,
                     results_file=em_results_file,
                     **self.inject_parameters_into_kwargs(env_mapping, earthmover_kwargs),
                     pool=self.earthmover_pool,

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -9,7 +9,6 @@ from airflow.exceptions import AirflowFailException, AirflowSkipException
 from airflow.models.param import Param
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator
-from airflow.operators.python import get_current_context
 from airflow.utils.helpers import chain
 from airflow.utils.task_group import TaskGroup
 
@@ -954,12 +953,10 @@ class EarthbeamDAG:
             }
         
         @task
-        def em_to_snowflake(s3_destination_dir: str, endpoint: str):
+        def em_to_snowflake(s3_destination_dir: str, endpoint: str, **context):
             # Snowflake tables are snake_cased; Earthmover outputs are camelCased
             snake_endpoint = edfi_api_client.camel_to_snake(endpoint)
             camel_endpoint = edfi_api_client.snake_to_camel(endpoint)
-
-            context = get_current_context()  # Retrieve context manually to exclude conf.
 
             # Descriptors have their own table
             if 'descriptor' in snake_endpoint:
@@ -986,7 +983,7 @@ class EarthbeamDAG:
                 dag=self.dag
             )
 
-            return sideload_op.execute(**context)
+            return sideload_op.execute(context)
     
         @task_group(prefix_group_id=True, dag=self.dag)
         def sideload_to_stadium(s3_destination_dir: str):

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -718,7 +718,7 @@ class EarthbeamDAG:
 
                 return sideload_op.execute(context)
         
-            @task_group(prefix_group_id=True)
+            @task_group(prefix_group_id=True, dag=self.dag)
             def sideload_to_stadium(s3_destination_dir: str):
                 if not s3_conn_id:
                     raise Exception("S3 connection required to copy into Snowflake.")

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -277,7 +277,6 @@ class EarthbeamDAG:
 
         assessment_bundle: Optional[str] = None,
         student_id_match_rates_table: Optional[str] = None,
-        required_match_rate: Optional[int] = 0.5,
 
         # Mapping of input environment variables to be injected into the taskgroup.
         input_file_mapping: Optional[dict] = None,
@@ -285,8 +284,8 @@ class EarthbeamDAG:
         **kwargs
     ):
         """
-        (Python) -> (S3: Raw) -> (Student ID) -> Earthmover -> (S3: EM Output) -> (Snowflake: EM Logs) +-> (Lightbeam) -> (Snowflake: LB Logs) +-> (Python) +-> Clean-up
-                                                                                                       +-> (Snowflake: EM Output)
+        (Python) -> (S3: Raw) -> (Student IDs) -> Earthmover -> (S3: EM Output) -> (Snowflake: EM Logs)  -> (Snowflake: Student IDs) +-> (Lightbeam) -> (Snowflake: LB Logs) +-> (Python) +-> Clean-up
+                                                                                                                                     +-> (Snowflake: EM Output)
 
         Many steps are automatic based on arguments defined:
         * If `edfi_conn_id` is defined, use Lightbeam to post to ODS.
@@ -329,7 +328,6 @@ class EarthbeamDAG:
 
         :param assessment_bundle:
         :param student_id_match_rates_table: 
-        :param required_match_rate:
 
         :param input_file_mapping:
 
@@ -526,7 +524,7 @@ class EarthbeamDAG:
                     dag=self.dag
                 )
                 list_files_task >> failed_sentinel
-            
+
             em_task_group = self.build_file_to_edfi_taskgroup(
                 tenant_code=tenant_code,
                 api_year=api_year,

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -729,7 +729,7 @@ class EarthbeamDAG:
         @task_group(prefix_group_id=True, group_id="file_to_earthbeam", dag=self.dag)
         def file_to_edfi_taskgroup(input_file_envs: Union[str, List[str]], input_filepaths: Union[str, List[str]]):
 
-            @task(dag=self.dag)
+            @task(pool=self.pool, dag=self.dag)
             def upload_to_s3(filepaths: Union[str, List[str]], subdirectory: str, **context):
                 if not s3_filepath:
                     raise ValueError(
@@ -756,7 +756,7 @@ class EarthbeamDAG:
 
                 return s3_full_filepath
             
-            @task(dag=self.dag)
+            @task(pool=self.pool, dag=self.dag)
             def log_to_snowflake(results_filepath: str, **context):
                 return self.log_to_snowflake(
                     snowflake_conn_id=snowflake_conn_id,
@@ -768,7 +768,7 @@ class EarthbeamDAG:
                     **context
                 )
             
-            @task(dag=self.dag)
+            @task(pool=self.pool, dag=self.dag)
             def check_existing_match_rates():
                 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
                 from snowflake.connector import DictCursor
@@ -789,7 +789,7 @@ class EarthbeamDAG:
                 else:
                     return None
             
-            @task(multiple_outputs=True, dag=self.dag)
+            @task(multiple_outputs=True, pool=self.earthmover_pool, dag=self.dag)
             def run_earthmover(input_file_envs: Union[str, List[str]], input_filepaths: Union[str, List[str]], max_match_rate: Optional[bool] = None, **context):
                 input_file_envs = [input_file_envs] if isinstance(input_file_envs, str) else input_file_envs
                 input_filepaths = [input_filepaths] if isinstance(input_filepaths, str) else input_filepaths
@@ -852,7 +852,6 @@ class EarthbeamDAG:
                     snowflake_read_conn_id=snowflake_read_conn_id,
                     results_file=em_results_file,
                     **self.inject_parameters_into_kwargs(env_mapping, earthmover_kwargs),
-                    pool=self.earthmover_pool,
                     dag=self.dag
                 )
                 
@@ -862,7 +861,7 @@ class EarthbeamDAG:
                     "results_file": em_results_file,
                 }
             
-            @task(multiple_outputs=True, dag=self.dag)
+            @task(multiple_outputs=True, pool=self.lightbeam_pool, dag=self.dag)
             def run_lightbeam(data_dir: str, lb_edfi_conn_id: str, command: str, **context):
                 dir_basename = self.get_filename(data_dir)
 
@@ -888,7 +887,6 @@ class EarthbeamDAG:
                     results_file=lb_results_file ,
                     edfi_conn_id=lb_edfi_conn_id,
                     **(lightbeam_kwargs or {}),
-                    pool=self.lightbeam_pool,
                     command=command,
                     dag=self.dag
                 )
@@ -899,7 +897,7 @@ class EarthbeamDAG:
                     "results_file": lb_results_file,
                 }
             
-            @task(dag=self.dag)
+            @task(pool=self.pool, dag=self.dag)
             def em_to_snowflake(s3_destination_dir: str, endpoint: str, **context):
                 # Snowflake tables are snake_cased; Earthmover outputs are camelCased
                 snake_endpoint = edfi_api_client.camel_to_snake(endpoint)
@@ -946,7 +944,7 @@ class EarthbeamDAG:
                 for endpoint in endpoints:
                     em_to_snowflake.override(task_id=f"copy_s3_to_snowflake__{endpoint}")(s3_destination_dir, endpoint)
 
-            @task(dag=self.dag)
+            @task(pool=self.pool, dag=self.dag)
             def match_rates_to_snowflake(s3_full_filepath:str):
                 from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
 
@@ -985,12 +983,12 @@ class EarthbeamDAG:
 
                 return
 
-            @task(dag=self.dag)
+            @task(pool=self.pool, dag=self.dag)
             def run_python_postprocess(python_postprocess_callable: Callable, python_postprocess_kwargs: dict, em_data_dir: str, em_s3_filepath: Optional[str], **context):
                 python_postprocess = python_postprocess_callable(**python_postprocess_kwargs, em_data_dir=em_data_dir, em_s3_filepath=em_s3_filepath, **context)
                 return python_postprocess
 
-            @task(trigger_rule="all_done" if self.fast_cleanup else "all_success", dag=self.dag)
+            @task(trigger_rule="all_done" if self.fast_cleanup else "all_success", pool=self.pool, dag=self.dag)
             def remove_files(filepaths):
                 unnested_filepaths = []
                 for filepath in filepaths:

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -810,7 +810,7 @@ class EarthbeamDAG:
                             'SNOWFLAKE_TENANT_CODE': tenant_code
                         })
                         # Don't overwrite if this was provided as an earthmover param (used for loading historical files using a current year of roster data)
-                        if 'SNOWFLAKE_API_YEAR' not in env_mapping:
+                        if 'SNOWFLAKE_API_YEAR' not in earthmover_kwargs['parameters']:
                             env_mapping['SNOWFLAKE_API_YEAR'] = api_year
 
                     # Add params for querying existing match rates if a high enough match has previously been found

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -607,7 +607,7 @@ class EarthbeamDAG:
                 input_filepaths = list(input_filepaths)
                 env_mapping = dict(zip(input_file_envs, input_filepaths))
                 
-                file_basename = self.get_filename(env_mapping.values()[0])
+                file_basename = self.get_filename(list(env_mapping.values())[0])
                 
                 em_output_dir = edfi_api_client.url_join(
                     self.em_output_directory,

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -992,7 +992,7 @@ class EarthbeamDAG:
                 raise Exception("No endpoints defined for ODS-bypass!")
 
             for endpoint in endpoints:
-                em_to_snowflake(s3_destination_dir, endpoint)
+                em_to_snowflake.override(task_id=f"copy_s3_to_snowflake__{endpoint}")(s3_destination_dir, endpoint)
 
 
         all_tasks = []  # Track all tasks to apply cleanup at the very end

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -857,8 +857,7 @@ class EarthbeamDAG:
                 s3_conn_id=s3_conn_id,
                 s3_destination_key=s3_full_filepath,
                 local_filepath=filepath,
-                remove_local_filepath=False,
-                **{key: val for key, val in context.items() if key != 'conf'}  # TODO: Why is this necessary?
+                remove_local_filepath=False
             )
         
         @task

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -605,7 +605,8 @@ class EarthbeamDAG:
                 )
             
             @task(multiple_outputs=True)
-            def run_earthmover(env_mapping: dict, **context):
+            def run_earthmover(**context):
+                env_mapping = dict(zip(input_file_envs, input_filepaths))
                 file_basename = self.get_filename(env_mapping.values()[0])
                 
                 em_output_dir = edfi_api_client.url_join(
@@ -752,7 +753,7 @@ class EarthbeamDAG:
                 all_tasks.append(upload_to_s3)
                 
             # EarthmoverOperator: Required
-            earthmover_results = run_earthmover(dict(zip(input_file_envs, input_filepaths)))
+            earthmover_results = run_earthmover()
             all_tasks.append(earthmover_results)
             paths_to_clean.append(earthmover_results["data_dir"])
 

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -359,7 +359,6 @@ class EarthbeamDAG:
             edfi_conn_id=edfi_conn_id, snowflake_conn_id=snowflake_conn_id, s3_conn_id=s3_conn_id
         )
 
-
         with TaskGroup(
             group_id=group_id,
             prefix_group_id=True,
@@ -442,13 +441,12 @@ class EarthbeamDAG:
         tenant_code: str, api_year: str, grain_update: Optional[str], *,
         edfi_conn_id: bool, snowflake_conn_id: bool, s3_conn_id: bool,
     ) -> str:
-        taskgroup_grain = f"{tenant_code}_{api_year}"
+        group_id = f"{tenant_code}_{api_year}"
         if grain_update:
-            taskgroup_grain += f"_{grain_update}"
+            group_id += f"_{grain_update}"
 
         # Group ID can be defined manually or built dynamically
-        if not group_id:
-            group_id = f"{taskgroup_grain}__earthmover"
+            group_id += "__earthmover"
 
             # TaskGroups have three shapes:
             if edfi_conn_id:         # Earthmover-to-Lightbeam (with optional S3)

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -1108,6 +1108,7 @@ class EarthbeamDAG:
                     file_basename
                 )
                 em_output_dir = context['task'].render_template(em_output_dir, context)
+                context['ti'].xcom_push(key='match_rates_file', value=existing_file)
 
                 em_state_file = edfi_api_client.url_join(
                     self.emlb_state_directory,
@@ -1126,10 +1127,12 @@ class EarthbeamDAG:
                     pool=self.earthmover_pool,
                     dag=self.dag
                 )
-
                 earthmover_operator.execute(**context)
+
+                match_rates_file = os.path.join(em_output_dir, 'student_id_match_rates.csv')
+                context['ti'].xcom_push(key='match_rates_file', value=match_rates_file) # Push extra xcom for consistent access downsteam whether this task runs or skips
                 
-                return os.path.join(em_output_dir, 'student_id_match_rates.csv')
+                return match_rates_file 
             
             @task (dag=self.dag)
             def match_rates_to_snowflake(match_rates_file, **context):

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -807,7 +807,7 @@ class EarthbeamDAG:
                 env_mapping = dict(zip(input_file_envs, input_filepaths))
 
                 match_rates_task_id = f"{context['task'].task_id.partition('.')[0]}.student_id_xwalking.run_em_compute_match_rates"
-                match_rates_file = context['ti'].xcom_pull(match_rates_task_id)
+                match_rates_file = context['ti'].xcom_pull(match_rates_task_id, key='match_rates_file')
 
                 if match_rates_file is not None:
                     env_mapping['STUDENT_ID_MATCH_RATES'] = match_rates_file
@@ -1143,7 +1143,7 @@ class EarthbeamDAG:
                 s3_full_filepath = edfi_api_client.url_join(
                     s3_filepath, "earthmover_config",
                     tenant_code, self.run_type, api_year, grain_update,
-                    '{{ ds_nodash }}', '{{ ts_nodash }}'
+                    '{{ ds_nodash }}', '{{ ts_nodash }}', 'student_id_match_rates.csv'
                 )
                 s3_full_filepath = context['task'].render_template(s3_full_filepath, context)
 
@@ -1172,7 +1172,7 @@ class EarthbeamDAG:
                             {api_year} as api_year,
                             '{assessment_name}' as assessment_name,
                             $1, $2, $3, $4, $5
-                        FROM @{database}.util.airflow_stage/{s3_full_filepath}/student_id_match_rates.csv)
+                        FROM @{database}.util.airflow_stage/{s3_full_filepath})
                         FILE_FORMAT = (TYPE = CSV SKIP_HEADER = 1)
                 '''
 

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -296,7 +296,7 @@ class EarthbeamDAG:
                     and key.lower() != "input_filetype"
                 }
 
-            em_task_group = self.file_to_edfi_taskgroup(
+            em_task_group = self.build_file_to_edfi_taskgroup(
                 tenant_code=tenant_code,
                 api_year=api_year,
                 grain_update=grain_update,

--- a/edu_edfi_airflow/providers/earthbeam/operators.py
+++ b/edu_edfi_airflow/providers/earthbeam/operators.py
@@ -25,7 +25,7 @@ class EarthmoverOperator(BashOperator):
         selector   : Optional[Union[str, Iterable[str]]] = None,
         parameters : Optional[Union[str, dict]] = None,
         results_file: Optional[str] = None,
-        database_conn_id: Optional[str] = None,
+        snowflake_read_conn_id: Optional[str] = None,
 
         force          : bool = False,
         skip_hashing   : bool = False,
@@ -37,7 +37,7 @@ class EarthmoverOperator(BashOperator):
         self.earthmover_path = earthmover_path
         self.output_dir = output_dir
         self.state_file = state_file
-        self.database_conn_id = database_conn_id
+        self.snowflake_read_conn_id = snowflake_read_conn_id
 
         ### Building the Earthmover CLI command
         self.arguments = {}
@@ -85,11 +85,10 @@ class EarthmoverOperator(BashOperator):
         :param context:
         :return:
         """
-        # Construct a database connection string and add as an environment variable if defined
-        # This database connection is used as a source for Earthmover. Currently only Snowflake is supported
+        # Construct a Snowflake connection string and add as an environment variable. Currently only Snowflake is supported
         # (This must be done in execute to prevent extraction during DAG-parsing)
-        if self.database_conn_id:
-            db_conn = Connection.get_connection_from_secrets(self.database_conn_id)
+        if self.snowflake_read_conn_id:
+            db_conn = Connection.get_connection_from_secrets(self.snowflake_read_conn_id)
             database_conn_string = f"snowflake://{db_conn.login}:{db_conn.password}@{db_conn.extra_dejson['extra__snowflake__account']}"
             self.env['SNOWFLAKE_CONNECTION'] = database_conn_string
 

--- a/edu_edfi_airflow/providers/earthbeam/operators.py
+++ b/edu_edfi_airflow/providers/earthbeam/operators.py
@@ -91,7 +91,7 @@ class EarthmoverOperator(BashOperator):
         if self.database_conn_id:
             db_conn = Connection.get_connection_from_secrets(self.database_conn_id)
             database_conn_string = f"snowflake://{db_conn.login}:{db_conn.password}@{db_conn.extra_dejson['extra__snowflake__account']}"
-            self.env['DATABASE_CONNECTION'] = database_conn_string
+            self.env['SNOWFLAKE_CONNECTION'] = database_conn_string
 
         # Format values before adding to the bash command.
         cli_arguments = []


### PR DESCRIPTION
## Description & motivation
This PR adds the ability to use the new [student ID earthmover package](https://github.com/edanalytics/earthmover_edfi_bundles/tree/student_id_alignment_unified/packages/student_ids) to the `EarthbeamDAG`. It adds three optional tasks to the `file_to_edfi_taskgroup`:
- `check_existing_match_rates` (pre-earthmover): Queries the match rates table in Snowflake and returns the highest computed ID match rate for the tenant, year, and assessment. If this value is too low (or none is found), matches will be recomputed during the EM run.
- `match_rates_to_snowflake` (post-earthmover): Loads computed match rates to Snowflake 

It also modifies the `run_earthmover` task to add the parameters required for the student ID bundle if needed. 
It is currently in draft status while testing continues.

## Usage
Three new and three existing task-group level args are required to use the student ID features, and one is optional:
- `assessment_bundle`: name of the assessment bundle being run, used for selecting the correct bundle and as metadata in the match rates table
- `student_id_match_rates_table`: Snowflake table set up for storing student ID match rates (`[db].[schema].[table]`)
- `snowflake_read_conn_id`: Connection ID for Snowflake creds with read access to `analytics`
- `s3_conn_id`, `s3_filepath`, `snowflake_conn_id`: existing args used to send the match rates data to Snowflake
- `required_id_match_rate`: optional, provide if overwriting the default of 0.5

Because the student ID process uses project composition, `earthmover deps` will need to be run to install the packages. More details on this to come in a migration guide. For a preview, see the testing instructions linked below.

## Breaking Changes
The argument `database_conn_id` is renamed to `snowflake_read_conn_id` for clarity. It also creates an earthmover parameter called `SNOWFLAKE_CONNECTION` instead of `DATABASE_CONNECTION` to align with the student ID bundle.

## PR Merge Priority:
High, once testing is complete

## Tests and QC done:
This has been successfully tested in GSN and testing is in progress in TX. Instructions for testing can be found [here](https://edanalytics.slite.com/app/docs/tUHJE4FljTPNsN). 
