### PR TITLE
Feature/optionalize raw dir

### DIFF
--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -246,7 +246,7 @@ class EarthbeamDAG:
     def build_tenant_year_taskgroup(self,
         tenant_code: str,
         api_year: int,
-        raw_dir: str,  # TODO: What role does raw_dir serve? Why was it even here when I first developed this?
+        raw_dir: Optional[str] = None,  # Deprecated in favor of `input_file_mapping`.
 
         *,
         grain_update: Optional[str] = None,
@@ -405,7 +405,7 @@ class EarthbeamDAG:
     def build_dynamic_tenant_year_taskgroup(self,
         tenant_code: str,
         api_year: int,
-        raw_dir: str,
+        raw_dir: Optional[str] = None,
 
         *,
         grain_update: Optional[str] = None,
@@ -459,6 +459,9 @@ class EarthbeamDAG:
             task_order = []
 
             ### PythonOperator Preprocess
+            if bool(python_callable) == bool(raw_dir):
+                raise ValueError("Taskgroup arguments `python_callable` and `raw_dir` are mutually exclusive.")
+
             if python_callable:
 
                 if logging_table:

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -704,10 +704,10 @@ class EarthbeamDAG:
             
             @task(dag=self.dag)
             def log_to_snowflake(results_filepath: str, **context):
-                return self.insert_earthbeam_result_to_logging_table(
+                return self.log_to_snowflake(
                     snowflake_conn_id=snowflake_conn_id,
                     logging_table=logging_table,
-                    results_filepath=results_filepath,
+                    log_filepath=results_filepath,
                     tenant_code=tenant_code,
                     api_year=api_year,
                     grain_update=grain_update,


### PR DESCRIPTION
This PR makes the following changes:
- Deprecate `raw_dir` argument in `build_tenant_year_task_group()`.
- Make `raw_dir` and `python_preprocess_callable` mutually-exclusive arguments in `build_dynamic_tenant_year_task_group()`

@rlittle08 Additionally, I've copied Python preprocess logging logic into the dynamic task group code. I feel like its absence was a bug, but let me know if this is not the case.