### PR TITLE
make optional the get cv with deltas

### DIFF
--- a/edu_edfi_airflow/dags/edfi_resource_dag.py
+++ b/edu_edfi_airflow/dags/edfi_resource_dag.py
@@ -528,7 +528,7 @@ class EdFiResourceDAG:
                     get_key_changes=get_key_changes,
                     min_change_version=self.xcom_pull_template_get_key(get_cv_operator, endpoint) if get_cv_operator else None,
                     max_change_version=airflow_util.xcom_pull_template(self.newest_edfi_cv_task_id),
-                    reverse_paging=self.get_deletes_cv_with_deltas,
+                    reverse_paging=self.get_deletes_cv_with_deltas if get_deletes else True,
 
                     # Optional config-specified run-attributes (overridden by those in configs)
                     **self.endpoint_configs[endpoint],
@@ -656,7 +656,7 @@ class EdFiResourceDAG:
                     get_deletes=get_deletes,
                     get_key_changes=get_key_changes,
                     max_change_version=airflow_util.xcom_pull_template(self.newest_edfi_cv_task_id),
-                    reverse_paging=self.get_deletes_cv_with_deltas,
+                    reverse_paging=self.get_deletes_cv_with_deltas if get_deletes else True,
 
                     # Only run endpoints specified at DAG or delta-level.
                     enabled_endpoints=enabled_endpoints,
@@ -778,7 +778,7 @@ class EdFiResourceDAG:
                 get_deletes=get_deletes,
                 get_key_changes=get_key_changes,
                 max_change_version=airflow_util.xcom_pull_template(self.newest_edfi_cv_task_id),
-                reverse_paging=self.get_deletes_cv_with_deltas,
+                reverse_paging=self.get_deletes_cv_with_deltas if get_deletes else True,
 
                 # Arguments that are required to be lists in Ed-Fi bulk-operator.
                 resource=endpoints,

--- a/edu_edfi_airflow/dags/edfi_resource_dag.py
+++ b/edu_edfi_airflow/dags/edfi_resource_dag.py
@@ -364,7 +364,8 @@ class EdFiResourceDAG:
         task_id: str,
         endpoints: List[Tuple[str, str]],
         get_deletes: bool = False,
-        get_key_changes: bool = False
+        get_key_changes: bool = False,
+        get_with_deltas: bool = True
     ) -> PythonOperator:
         """
 
@@ -372,7 +373,7 @@ class EdFiResourceDAG:
         """
         get_cv_operator = PythonOperator(
             task_id=task_id,
-            python_callable=change_version.get_previous_change_versions_with_deltas,
+            python_callable=change_version.get_previous_change_versions_with_deltas if get_with_deltas else change_version.get_previous_change_versions,
             op_kwargs={
                 'tenant_code': self.tenant_code,
                 'api_year': self.api_year,

--- a/edu_edfi_airflow/dags/edfi_resource_dag.py
+++ b/edu_edfi_airflow/dags/edfi_resource_dag.py
@@ -528,6 +528,7 @@ class EdFiResourceDAG:
                     get_key_changes=get_key_changes,
                     min_change_version=self.xcom_pull_template_get_key(get_cv_operator, endpoint) if get_cv_operator else None,
                     max_change_version=airflow_util.xcom_pull_template(self.newest_edfi_cv_task_id),
+                    reverse_paging=self.get_deletes_cv_with_deltas,
 
                     # Optional config-specified run-attributes (overridden by those in configs)
                     **self.endpoint_configs[endpoint],
@@ -655,6 +656,7 @@ class EdFiResourceDAG:
                     get_deletes=get_deletes,
                     get_key_changes=get_key_changes,
                     max_change_version=airflow_util.xcom_pull_template(self.newest_edfi_cv_task_id),
+                    reverse_paging=self.get_deletes_cv_with_deltas,
 
                     # Only run endpoints specified at DAG or delta-level.
                     enabled_endpoints=enabled_endpoints,
@@ -776,6 +778,7 @@ class EdFiResourceDAG:
                 get_deletes=get_deletes,
                 get_key_changes=get_key_changes,
                 max_change_version=airflow_util.xcom_pull_template(self.newest_edfi_cv_task_id),
+                reverse_paging=self.get_deletes_cv_with_deltas,
 
                 # Arguments that are required to be lists in Ed-Fi bulk-operator.
                 resource=endpoints,

--- a/edu_edfi_airflow/providers/edfi/transfers/edfi_to_s3.py
+++ b/edu_edfi_airflow/providers/edfi/transfers/edfi_to_s3.py
@@ -185,7 +185,7 @@ class EdFiToS3Operator(BaseOperator):
             paged_iter = resource_endpoint.get_pages(
                 page_size=page_size,
                 step_change_version=step_change_version, change_version_step_size=change_version_step_size,
-                reverse_paging=(self.reverse_paging)
+                reverse_paging=(self.reverse_paging),
                 retry_on_failure=True, max_retries=num_retries
             )
 

--- a/edu_edfi_airflow/providers/edfi/transfers/edfi_to_s3.py
+++ b/edu_edfi_airflow/providers/edfi/transfers/edfi_to_s3.py
@@ -50,6 +50,7 @@ class EdFiToS3Operator(BaseOperator):
         page_size: int = 500,
         num_retries: int = 5,
         change_version_step_size: int = 50000,
+        reverse_paging: bool = True,
         query_parameters  : Optional[dict] = None,
 
         enabled_endpoints: Optional[List[str]] = None,
@@ -79,6 +80,7 @@ class EdFiToS3Operator(BaseOperator):
         self.page_size = page_size
         self.num_retries = num_retries
         self.change_version_step_size = change_version_step_size
+        self.reverse_paging = reverse_paging
         self.query_parameters = query_parameters
 
         # Optional variable to allow immediate skips when endpoint not specified in dynamic get-change-version output.
@@ -183,6 +185,7 @@ class EdFiToS3Operator(BaseOperator):
             paged_iter = resource_endpoint.get_pages(
                 page_size=page_size,
                 step_change_version=step_change_version, change_version_step_size=change_version_step_size,
+                reverse_paging=(self.reverse_paging)
                 retry_on_failure=True, max_retries=num_retries
             )
 


### PR DESCRIPTION
Through our work with Boston (who uses their own implementation of Ed-Fi ODS/API v5.3, not the CQE version implemented by startingblocks), we found that some of the recent updates to force use of Total-Count on deletes may be incompatible with base v5.3 code. 

This branch adds var `get_deletes_cv_with_deltas` to the `EdFiResourceDAG`, which is by default True, but allows implementations to override with False, to implement the non-deltas version of get_change_versions for deletes. This functionality will be used in Boston until they upgrade to Ed-Fi 7