### PR TITLE
Feature/pull all deletes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Alternatively, use argument `schedule_interval_full_refresh` to set an automatic
 | schedule_interval_full_refresh | CRON schedule that automatically triggers a full-refresh, instead of the default delta run (default `None`)                                        |
 | use_change_version             | Boolean flag for using change versions to complete delta ingests (default `True`; turned off for Ed-Fi2)                                           |
 | get_key_changes                | Boolean flag for whether to build a /keyChanges task-group (only applicable in newer ODSes; default `False`)                                       |
+| get_deletes_cv_with_deltas     | Boolean flag for whether to use Total-Count for reverse paging deletes (default `True`; change only if API version does not have Total-Count)      |
+| pull_all_deletes               | Boolean flag for whether to always pull all deletes to ensure suppressed deletes are captured (default `True`; recommended for accuracy)           |
 | run_type                       | Specifies the run-type for the Ed-Fi task groups in the DAG (default `'default'`)                                                                  |
 | resource_configs               | An {endpoint: metadata} dictionary to populate the DAG (replaces deprecated `add_resource()` and `add_resource_deletes()` methods; default `None`) |
 | descriptor_configs             | An {endpoint: metadata} dictionary to populate the DAG (replaces deprecated `add_descriptor()` method; default `None`)                             |

--- a/edu_edfi_airflow/dags/edfi_resource_dag.py
+++ b/edu_edfi_airflow/dags/edfi_resource_dag.py
@@ -532,7 +532,7 @@ class EdFiResourceDAG:
                     get_deletes=get_deletes,
                     get_key_changes=get_key_changes,
                     min_change_version=self.xcom_pull_template_get_key(get_cv_operator, endpoint) if get_cv_operator else None,
-                    max_change_version=airflow_util.xcom_pull_template(self.newest_edfi_cv_task_id),
+                    max_change_version=airflow_util.xcom_pull_template(self.newest_edfi_cv_task_id) if not get_deletes else None,
                     reverse_paging=self.get_deletes_cv_with_deltas if get_deletes else True,
 
                     # Optional config-specified run-attributes (overridden by those in configs)
@@ -634,7 +634,7 @@ class EdFiResourceDAG:
                 enabled_endpoints = self.xcom_pull_template_map_idx(get_cv_operator, 0)
                 kwargs_dicts = get_cv_operator.output.map(lambda endpoint__cv: {
                     'resource': endpoint__cv[0],
-                    'min_change_version': endpoint__cv[1] if not get_deletes else None,
+                    'min_change_version': endpoint__cv[1] if not get_deletes else 0,
                     's3_destination_filename': f"{endpoint__cv[0]}.jsonl",
                     **self.endpoint_configs[endpoint__cv[0]],
                 })
@@ -760,7 +760,7 @@ class EdFiResourceDAG:
                     get_with_deltas=get_with_deltas
                 )
                 min_change_versions = [
-                    self.xcom_pull_template_get_key(get_cv_operator, endpoint) if not get_deletes else None
+                    self.xcom_pull_template_get_key(get_cv_operator, endpoint) if not get_deletes else 0
                     for endpoint in endpoints
                 ]
                 enabled_endpoints = self.xcom_pull_template_map_idx(get_cv_operator, 0)


### PR DESCRIPTION
## Description & motivation
This PR addresses a potential source of error in our Ed-Fi data pulls. When a record is deleted but then a new record is created with the same natural key, the delete won't be returned by an API call pulling recent change versions. This can cause us to miss delete records and end up with orphan records. These are typically handled by the deduplication step in the `edu_edfi_source` staging models, but we could still surface these records if the newest version is also deleted. To avoid this scenario, we need to pull all of an endpoint's deletes whenever a new delete is recorded. 

[Internal reference doc](https://edanalytics.slite.com/app/docs/jZTUSJ9w54-fdx)

## PR Merge Priority:
- Low 

## Changes to existing files:
- `edfi_resource_dag.py`:  Adds class-level arg `pull_all_deletes`. When True, all deletes will be pulled for any endpoint with new deletes since the last successful run. Previous delete records are deleted from Snowflake before the new records are copied in.

## Tests and QC done
Successfully ran in GSN dev with all three run types. Will run it on a schedule for the next week or so to compare performance to prod

## Questions / discussion points
- Would like to get some more opinions on the name of the arg and README description
