### PR TITLE
Hotfix/override snowflake tenant code

### DIFF
--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -820,8 +820,11 @@ class EarthbeamDAG:
                         env_mapping.update({
                             'EDFI_ROSTER_SOURCE_TYPE': 'snowflake',
                             'SNOWFLAKE_EDU_STG_SCHEMA': 'analytics.prod_stage',
-                            'SNOWFLAKE_TENANT_CODE': tenant_code
                         })
+                        # Don't overwrite if this was provided as an earthmover param (used for handling consolidated districts in ODS years)
+                        if 'SNOWFLAKE_TENANT_CODE' not in earthmover_kwargs['parameters']:
+                            env_mapping['SNOWFLAKE_TENANT_CODE'] = tenant_code
+
                         # Don't overwrite if this was provided as an earthmover param (used for loading historical files using a current year of roster data)
                         if 'SNOWFLAKE_API_YEAR' not in earthmover_kwargs['parameters']:
                             env_mapping['SNOWFLAKE_API_YEAR'] = api_year


### PR DESCRIPTION
Only lines 823 through 827 are relevant for this PR; the other changes are part of `hotfix/force_lightbeam_dependencies`. (I needed to merge these for testing in SC.)

There is one district in South Carolina that has been consolidated and cannot be referenced directly in the student ID match Snowflake query. This PR allows the user to override a tenant code in the query in cases like these.

I've followed the same logic for overriding `SNOWFLAKE_API_YEAR` to maintain consistency and flexibility across implementations.