### PR TITLE
Add support for Airflow 2.9.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased changes
+## New features
+- Update Resources DAG UI for compatibility with Airflow 2.9.x (backwards compatibility with prior versions is retained)
+
 # edu_edfi_airflow v0.4.2
 ## New features
 - Add boolean `pull_all_deletes` argument to `EdFiResourceDAG` to re-pull all deletes for a resource when any are added (resolves deletes-skipping bug).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# edu_edfi_airflow v0.4.2
+## New features
+- Add boolean `pull_all_deletes` argument to `EdFiResourceDAG` to re-pull all deletes for a resource when any are added (resolves deletes-skipping bug).
+- Allow `SNOWFLAKE_TENANT_CODE` to be overridden in `earthmover_kwargs` in `EarthbeamDAG`.
+
+## Under the hood
+- Simplify taskgroup declaration in `EarthbeamDAG`.
+
+## Fixes
+- Fix bug where singleton filepaths in `EarthbeamDAG` were not converted to lists upon initialization.
+- Add dependency between Lightbeam and file-deletion in `EarthbeamDAG`.
+
+
 # edu_edfi_airflow v0.4.1
 ## Under the hood
 - Wrap Snowflake stage with single quotes to support filepaths with special characters

--- a/edu_edfi_airflow/callables/airflow_util.py
+++ b/edu_edfi_airflow/callables/airflow_util.py
@@ -76,7 +76,9 @@ def get_config_endpoints(context) -> List[str]:
     """
     # Apply camel_to_snake transform on all specified endpoints to circumvent user-input error.
     raw_endpoints = get_context_variable(context, 'endpoints', default=[])
-    return list(map(camel_to_snake, raw_endpoints))
+    if raw_endpoints is not None:
+        return list(map(camel_to_snake, raw_endpoints))
+    return []
 
 
 def xcom_pull_template(

--- a/edu_edfi_airflow/callables/change_version.py
+++ b/edu_edfi_airflow/callables/change_version.py
@@ -250,9 +250,10 @@ def update_change_versions(
             "There are no new change versions to update for any endpoints. All upstream tasks skipped or failed."
         )
     
-    # FIXME:
+    # we have to do this for the time being because the XCom that produces this list
+    # actually returns a lazily-evaluated object with no len() property
     endpoints = list(endpoints)
-    
+
     logging.info(f"Collected updated change versions for {len(endpoints)} endpoints.")
     
     # Deletes and KeyChanges are mutually-exclusive. Delete-status is original and required to output.

--- a/edu_edfi_airflow/callables/change_version.py
+++ b/edu_edfi_airflow/callables/change_version.py
@@ -250,6 +250,9 @@ def update_change_versions(
             "There are no new change versions to update for any endpoints. All upstream tasks skipped or failed."
         )
     
+    # FIXME:
+    endpoints = list(endpoints)
+    
     logging.info(f"Collected updated change versions for {len(endpoints)} endpoints.")
     
     # Deletes and KeyChanges are mutually-exclusive. Delete-status is original and required to output.

--- a/edu_edfi_airflow/dags/edfi_resource_dag.py
+++ b/edu_edfi_airflow/dags/edfi_resource_dag.py
@@ -453,7 +453,7 @@ class EdFiResourceDAG:
         Many XComs in this DAG are lists of tuples. This overloads xcom_pull_template to retrieve a list of items at a given index.
         """
         return airflow_util.xcom_pull_template(
-            task_ids, suffix=f" or [] | map(attribute={idx}) | list"
+            task_ids, suffix=f" | map(attribute={idx}) or [] | list"
         )
     
     @staticmethod

--- a/edu_edfi_airflow/dags/edfi_resource_dag.py
+++ b/edu_edfi_airflow/dags/edfi_resource_dag.py
@@ -128,7 +128,7 @@ class EdFiResourceDAG:
                 description="If true, deletes endpoint data in Snowflake before ingestion"
             ),
             "endpoints": Param(
-                default=sorted(list(self.resources | self.descriptors)),
+                #default=sorted(list(self.resources | self.descriptors)),
                 type=["array", "null"],
                 description="Newline-separated list of specific endpoints to ingest (case-agnostic)\n(Bug: even if unused, enter a newline)"
             ),
@@ -452,6 +452,7 @@ class EdFiResourceDAG:
         """
         Many XComs in this DAG are lists of tuples. This overloads xcom_pull_template to retrieve a list of items at a given index.
         """
+        print(f"SUFFIX --->> | map(attribute={idx}) | list")
         return airflow_util.xcom_pull_template(
             task_ids, suffix=f" | map(attribute={idx}) | list"
         )

--- a/edu_edfi_airflow/dags/edfi_resource_dag.py
+++ b/edu_edfi_airflow/dags/edfi_resource_dag.py
@@ -129,7 +129,7 @@ class EdFiResourceDAG:
             ),
             "endpoints": Param(
                 default=sorted(list(self.resources | self.descriptors)),
-                type="array",
+                type=["array", "null"],
                 description="Newline-separated list of specific endpoints to ingest (case-agnostic)\n(Bug: even if unused, enter a newline)"
             ),
         }

--- a/edu_edfi_airflow/dags/edfi_resource_dag.py
+++ b/edu_edfi_airflow/dags/edfi_resource_dag.py
@@ -452,9 +452,9 @@ class EdFiResourceDAG:
         """
         Many XComs in this DAG are lists of tuples. This overloads xcom_pull_template to retrieve a list of items at a given index.
         """
-        return airflow_util.xcom_pull_template(
-            task_ids, suffix=f" | map(attribute={idx}) or [] | list"
-        )
+        return list(airflow_util.xcom_pull_template(
+            task_ids, suffix=f" | map(attribute={idx}) | list"
+        ))
     
     @staticmethod
     def xcom_pull_template_get_key(task_ids, key: str):

--- a/edu_edfi_airflow/dags/edfi_resource_dag.py
+++ b/edu_edfi_airflow/dags/edfi_resource_dag.py
@@ -128,9 +128,9 @@ class EdFiResourceDAG:
                 description="If true, deletes endpoint data in Snowflake before ingestion"
             ),
             "endpoints": Param(
-                #default=sorted(list(self.resources | self.descriptors)),
+                default=sorted(list(self.resources | self.descriptors)),
                 type=["array", "null"],
-                description="Newline-separated list of specific endpoints to ingest (case-agnostic)\n(Bug: even if unused, enter a newline)"
+                description="Newline-separated list of specific endpoints to ingest (case-agnostic). If left blank, ingests all endpionts"
             ),
         }
 

--- a/edu_edfi_airflow/dags/edfi_resource_dag.py
+++ b/edu_edfi_airflow/dags/edfi_resource_dag.py
@@ -452,9 +452,9 @@ class EdFiResourceDAG:
         """
         Many XComs in this DAG are lists of tuples. This overloads xcom_pull_template to retrieve a list of items at a given index.
         """
-        return list(airflow_util.xcom_pull_template(
+        return airflow_util.xcom_pull_template(
             task_ids, suffix=f" | map(attribute={idx}) | list"
-        ))
+        )
     
     @staticmethod
     def xcom_pull_template_get_key(task_ids, key: str):

--- a/edu_edfi_airflow/dags/edfi_resource_dag.py
+++ b/edu_edfi_airflow/dags/edfi_resource_dag.py
@@ -452,9 +452,8 @@ class EdFiResourceDAG:
         """
         Many XComs in this DAG are lists of tuples. This overloads xcom_pull_template to retrieve a list of items at a given index.
         """
-        print(f"SUFFIX --->> | map(attribute={idx}) | list")
         return airflow_util.xcom_pull_template(
-            task_ids, suffix=f" | map(attribute={idx}) | list"
+            task_ids, suffix=f" or [] | map(attribute={idx}) | list"
         )
     
     @staticmethod

--- a/edu_edfi_airflow/providers/snowflake/transfers/s3_to_snowflake.py
+++ b/edu_edfi_airflow/providers/snowflake/transfers/s3_to_snowflake.py
@@ -172,8 +172,9 @@ class BulkS3ToSnowflakeOperator(S3ToSnowflakeOperator):
         # Force potential string columns into lists for zipping in execute.
         if isinstance(self.resource, str):
             raise ValueError("Bulk operators require lists of resources to be passed.")
-        
-        # FIXME: why do we have to do this?
+
+        # we have to do this for the time being because the XCom that produces this list
+        # actually returns a lazily-evaluated object with no len() property
         self.resource = list(self.resource)
 
         if isinstance(self.table_name, str):

--- a/edu_edfi_airflow/providers/snowflake/transfers/s3_to_snowflake.py
+++ b/edu_edfi_airflow/providers/snowflake/transfers/s3_to_snowflake.py
@@ -176,9 +176,6 @@ class BulkS3ToSnowflakeOperator(S3ToSnowflakeOperator):
         # we have to do this for the time being because the XCom that produces this list
         # actually returns a lazily-evaluated object with no len() property
         self.resource = list(self.resource)
-
-        if isinstance(self.table_name, str):
-            self.table_name = [self.table_name] * len(self.resource)
             
         ### Optionally set destination key by concatting separate args for dir and filename
         if not self.s3_destination_key:

--- a/edu_edfi_airflow/providers/snowflake/transfers/s3_to_snowflake.py
+++ b/edu_edfi_airflow/providers/snowflake/transfers/s3_to_snowflake.py
@@ -174,7 +174,7 @@ class BulkS3ToSnowflakeOperator(S3ToSnowflakeOperator):
             raise ValueError("Bulk operators require lists of resources to be passed.")
         
         # FIXME: why do we have to do this?
-        #self.resource = list(self.resource)
+        self.resource = list(self.resource)
 
         if isinstance(self.table_name, str):
             self.table_name = [self.table_name] * len(self.resource)

--- a/edu_edfi_airflow/providers/snowflake/transfers/s3_to_snowflake.py
+++ b/edu_edfi_airflow/providers/snowflake/transfers/s3_to_snowflake.py
@@ -172,6 +172,9 @@ class BulkS3ToSnowflakeOperator(S3ToSnowflakeOperator):
         # Force potential string columns into lists for zipping in execute.
         if isinstance(self.resource, str):
             raise ValueError("Bulk operators require lists of resources to be passed.")
+        
+        # FIXME: why do we have to do this?
+        self.resource = list(self.resource)
 
         if isinstance(self.table_name, str):
             self.table_name = [self.table_name] * len(self.resource)

--- a/edu_edfi_airflow/providers/snowflake/transfers/s3_to_snowflake.py
+++ b/edu_edfi_airflow/providers/snowflake/transfers/s3_to_snowflake.py
@@ -174,7 +174,7 @@ class BulkS3ToSnowflakeOperator(S3ToSnowflakeOperator):
             raise ValueError("Bulk operators require lists of resources to be passed.")
         
         # FIXME: why do we have to do this?
-        self.resource = list(self.resource)
+        #self.resource = list(self.resource)
 
         if isinstance(self.table_name, str):
             self.table_name = [self.table_name] * len(self.resource)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = (HERE / "README.md").read_text()
 
 setuptools.setup(
       name='edu_edfi_airflow',
-      version='0.4.4',
+      version='0.4.5',
 
       description='EDU Airflow tools for Ed-Fi',
       license_files=['LICENSE.md'],

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = (HERE / "README.md").read_text()
 
 setuptools.setup(
       name='edu_edfi_airflow',
-      version='0.4.1',
+      version='0.4.2',
 
       description='EDU Airflow tools for Ed-Fi',
       license_files=['LICENSE.md'],


### PR DESCRIPTION
  - Update Resources DAG UI for compatibility with Airflow 2.9.x (backwards compatibility with prior versions is retained)
  - Due to a [bug](https://github.com/apache/airflow/issues/43977) in Airflow 2.10, we must limit our version to 2.9 for the time being
  - Adds a couple of minor under-the-hood changes for compatibility

## Testing

  - Changes tested in two implementations, the upgraded Airflow appears to work fine
  - Changes tested for backwards compatibility with Airflow 2.6