### PR TITLE
capture earthmover failures in structured logging table

### DIFF
--- a/edu_edfi_airflow/callables/log_util.py
+++ b/edu_edfi_airflow/callables/log_util.py
@@ -36,7 +36,8 @@ def structured_log_capture(args, kwargs, logger_name: str = "airflow.task"):
 
     class StructuredLogHandler(logging.Handler):
         def emit(self, record):
-            log_records.append(format_log_record(record, args, kwargs))
+            if record.levelno >= logging.ERROR:  # only log warnings/errors
+                log_records.append(format_log_record(record, args, kwargs))
 
     handler = StructuredLogHandler()
     logger = logging.getLogger(logger_name)

--- a/edu_edfi_airflow/callables/log_util.py
+++ b/edu_edfi_airflow/callables/log_util.py
@@ -78,8 +78,8 @@ def capture_logs_to_snowflake(
     logging_table: str,
     tenant_code: str,
     api_year: int,
-    grain_update: Optional[str] = None,
-    run_type: str
+    run_type: str,
+    grain_update: Optional[str] = None
 ):
     with structured_log_capture() as log_records:
         result = run_callable()

--- a/edu_edfi_airflow/callables/log_util.py
+++ b/edu_edfi_airflow/callables/log_util.py
@@ -114,6 +114,9 @@ def capture_logs_to_snowflake(
         with structured_log_capture(args, kwargs) as log_records:
             try:
                 return run_callable(*args, **kwargs)
+            except Exception as err:
+                logging.getLogger("airflow.task").exception("Earthmover failed during execution")  # <- key line
+                raise
             finally:
                 flush_logs(log_records)
 

--- a/edu_edfi_airflow/callables/log_util.py
+++ b/edu_edfi_airflow/callables/log_util.py
@@ -36,10 +36,7 @@ def structured_log_capture(args, kwargs, logger_name: str = "airflow.task"):
 
     class StructuredLogHandler(logging.Handler):
         def emit(self, record):
-            # Log exception traceback if present
-            if record.exc_info:
-                record.msg = f"{record.msg}\n{logging.Formatter().formatException(record.exc_info)}"
-                log_records.append(format_log_record(record, args, kwargs))
+            log_records.append(format_log_record(record, args, kwargs))
 
     handler = StructuredLogHandler()
     logger = logging.getLogger(logger_name)
@@ -97,7 +94,10 @@ def capture_logs_to_snowflake(
         context = kwargs.get("context", kwargs)
 
         def flush_logs(log_records):
+            logging.getLogger("airflow.task").info(f"[DEBUG] flushing {len(log_records)} log records to Snowflake")
             if snowflake_conn_id and log_records:
+                for r in log_records:
+                    print(json.loads(r).get("level"))
                 structured_logs = "[{}]".format(",".join(log_records))
                 log_to_snowflake(
                     snowflake_conn_id=snowflake_conn_id,

--- a/edu_edfi_airflow/callables/log_util.py
+++ b/edu_edfi_airflow/callables/log_util.py
@@ -94,7 +94,7 @@ def capture_logs_to_snowflake(
         context = kwargs.get("context", kwargs)
 
         def flush_logs(log_records):
-            logging.getLogger("airflow.task").info(f"[DEBUG] flushing {len(log_records)} log records to Snowflake")
+            logging.getLogger("airflow.task").info(f"[DEBUG] flushing {len(log_records)} log records to Snowflake: {snowflake_conn_id}")
             if snowflake_conn_id and log_records:
                 for r in log_records:
                     print(json.loads(r).get("level"))

--- a/edu_edfi_airflow/callables/log_util.py
+++ b/edu_edfi_airflow/callables/log_util.py
@@ -94,7 +94,7 @@ def capture_logs_to_snowflake(
         
         # Robustly extract the Airflow context
         context = (
-            kwargs.get("context") or
+            kwargs if kwargs and isinstance(kwargs, dict) and "ds" in kwargs and "ts" in kwargs else
             (args[0] if args and isinstance(args[0], dict) and "ds" in args[0] and "ts" in args[0] else None)
         )
         if not context:
@@ -126,7 +126,7 @@ def capture_logs_to_snowflake(
             try:
                 return run_callable(*args, **kwargs)
             except Exception as err:
-                logging.getLogger("airflow.task").exception("Earthmover failed during execution")  # <- key line
+                logging.getLogger("airflow.task").exception(f"{type(err).__name__} raised during task execution: {err}")
                 raise
             finally:
                 flush_logs(log_records, context)

--- a/edu_edfi_airflow/callables/log_util.py
+++ b/edu_edfi_airflow/callables/log_util.py
@@ -1,4 +1,4 @@
-# log_utils.py
+# log_util.py
 
 import logging
 import json
@@ -10,13 +10,13 @@ from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
 from edu_edfi_airflow.callables import airflow_util
 
 
-def format_log_record(record, args, kwargs):
-    def serialize_argument(arg):
-        try:
-            return json.dumps(arg)
-        except TypeError:
-            return str(arg)
+def serialize_argument(arg):
+    try:
+        return json.dumps(arg)
+    except TypeError:
+        return str(arg)
 
+def format_log_record(record, args, kwargs):
     log_record = {
         'timestamp': datetime.now(timezone.utc).isoformat(),
         'name': record.name,

--- a/edu_edfi_airflow/callables/log_util.py
+++ b/edu_edfi_airflow/callables/log_util.py
@@ -93,10 +93,7 @@ def capture_logs_to_snowflake(
     def wrapper(*args, **kwargs):
         
         # Robustly extract the Airflow context
-        context = (
-            kwargs if kwargs and isinstance(kwargs, dict) and "ds" in kwargs and "ts" in kwargs else
-            (args[0] if args and isinstance(args[0], dict) and "ds" in args[0] and "ts" in args[0] else None)
-        )
+        context = kwargs.get("context") or (kwargs if {"ds", "ts"} <= kwargs.keys() else None)
         if not context:
             raise ValueError("Airflow context not found. Cannot extract ds/ts.")
         

--- a/edu_edfi_airflow/callables/log_util.py
+++ b/edu_edfi_airflow/callables/log_util.py
@@ -1,0 +1,23 @@
+import logging
+import io
+from contextlib import contextmanager
+from typing import Generator, Optional
+
+@contextmanager
+def capture_log_stream(level=logging.INFO, logger_name: Optional[str] = None) -> Generator[str, None, None]:
+    """
+    Context manager that captures logs emitted during a block.
+    Returns the log contents as a string.
+    """
+    log_capture_string = io.StringIO()
+    handler = logging.StreamHandler(log_capture_string)
+    handler.setLevel(level)
+
+    logger = logging.getLogger(logger_name) if logger_name else logging.getLogger()
+    logger.addHandler(handler)
+
+    try:
+        yield log_capture_string
+    finally:
+        logger.removeHandler(handler)
+        handler.close()

--- a/edu_edfi_airflow/callables/log_util.py
+++ b/edu_edfi_airflow/callables/log_util.py
@@ -1,8 +1,13 @@
+# log_utils.py
+
 import logging
 import json
 from datetime import datetime, timezone
+from typing import Callable, Optional
 from contextlib import contextmanager
-from typing import List, Generator
+
+from airflow.providers.snowflake.hooks.snowflake import SnowflakeHook
+from edu_edfi_airflow.callables import airflow_util
 
 
 def format_log_record(record: logging.LogRecord) -> str:
@@ -17,10 +22,7 @@ def format_log_record(record: logging.LogRecord) -> str:
 
 
 @contextmanager
-def capture_logs(logger_name: str = "airflow.task") -> Generator[List[str], None, None]:
-    """
-    Context manager that captures structured log records and yields them as a list of JSON strings.
-    """
+def structured_log_capture(logger_name: str = "airflow.task"):
     log_records = []
 
     class StructuredLogHandler(logging.Handler):
@@ -36,3 +38,64 @@ def capture_logs(logger_name: str = "airflow.task") -> Generator[List[str], None
     finally:
         logger.removeHandler(handler)
         handler.close()
+
+
+def log_to_snowflake(
+    *,
+    snowflake_conn_id: str,
+    logging_table: str,
+    log_data: str,
+    tenant_code: str,
+    api_year: int,
+    run_type: str,
+    run_date: str,
+    run_timestamp: str,
+    grain_update: Optional[str] = None
+):
+    database, schema = airflow_util.get_snowflake_params_from_conn(snowflake_conn_id)
+    grain_update_str = f"'{grain_update}'" if grain_update else "NULL"
+
+    insert_sql = f"""
+        INSERT INTO {database}.{schema}.{logging_table}
+        (tenant_code, api_year, grain_update, run_type, run_date, run_timestamp, result)
+        SELECT
+            '{tenant_code}',
+            '{api_year}',
+            {grain_update_str},
+            '{run_type}',
+            '{run_date}',
+            '{run_timestamp}',
+            PARSE_JSON($${log_data}$$)
+    """
+
+    hook = SnowflakeHook(snowflake_conn_id=snowflake_conn_id)
+    hook.run(insert_sql)
+
+
+def capture_logs_to_snowflake(
+    run_callable: Callable,
+    snowflake_conn_id: str,
+    logging_table: str,
+    tenant_code: str,
+    api_year: int,
+    grain_update: Optional[str] = None,
+    run_type: str
+):
+    with structured_log_capture() as log_records:
+        result = run_callable()
+
+    if operator.snowflake_read_conn_id and log_records:
+        structured_logs = "[{}]".format(",".join(log_records))
+
+        log_to_snowflake(
+            snowflake_conn_id=snowflake_conn_id,
+            logging_table=logging_table,
+            log_data=structured_logs,
+            tenant_code=tenant_code,
+            api_year=api_year,
+            run_type=run_type,
+            grain_update=grain_update,
+            **kwargs
+        )
+
+    return result

--- a/edu_edfi_airflow/callables/log_util.py
+++ b/edu_edfi_airflow/callables/log_util.py
@@ -93,7 +93,7 @@ def capture_logs_to_snowflake(
     def wrapper(*args, **kwargs):
         context = kwargs.get("context", kwargs)
 
-        def flush_logs(log_records):
+        def flush_logs(log_records, context):
             logging.getLogger("airflow.task").info(f"[DEBUG] flushing {len(log_records)} log records to Snowflake: {snowflake_conn_id}")
             if snowflake_conn_id and log_records:
                 for r in log_records:
@@ -118,6 +118,6 @@ def capture_logs_to_snowflake(
                 logging.getLogger("airflow.task").exception("Earthmover failed during execution")  # <- key line
                 raise
             finally:
-                flush_logs(log_records)
+                flush_logs(log_records, context)
 
     return wrapper

--- a/edu_edfi_airflow/callables/log_util.py
+++ b/edu_edfi_airflow/callables/log_util.py
@@ -132,7 +132,7 @@ def capture_logs_to_snowflake(
                 run_timestamp=context.get("ts"),
             )
 
-        with structured_log_capture(args, kwargs) as log_records:
+        with structured_log_capture(args, kwargs=context) as log_records:
             try:
                 return run_callable(*args, **kwargs)
             except Exception as err:

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -1102,30 +1102,6 @@ class EarthbeamDAG:
 
         return file_to_edfi_taskgroup
 
-    @staticmethod
-    def format_log_record(record, args, kwargs):
-
-        from datetime import datetime, timezone
-        import json
-
-        def serialize_argument(arg):
-            try:
-                return json.dumps(arg)
-            except TypeError:
-                return str(arg)
-
-        log_record = {
-            'timestamp': datetime.now(timezone.utc).isoformat(),
-            'name': record.name,
-            'level': record.levelname,
-            'message': record.getMessage(),
-            'pathname': record.pathname,
-            'lineno': record.lineno,
-            'args': {k: serialize_argument(v) for k, v in enumerate(args)},
-            'kwargs': {k: serialize_argument(v) for k, v in kwargs.items()},
-        }
-        return json.dumps(log_record)
-
 
     def capture_logs(self,
         python_callable: Callable,

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -1148,9 +1148,7 @@ class EarthbeamDAG:
                 tenant_code=tenant_code,
                 api_year=api_year,
                 grain_update=grain_update,
-                run_type=self.run_type,
-                run_date=kwargs['ds'],
-                run_timestamp=kwargs['ts']
+                **kwargs
             )
             return result
         return wrapper

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -21,7 +21,7 @@ from edu_edfi_airflow.callables import airflow_util
 from edu_edfi_airflow.providers.earthbeam.operators import EarthmoverOperator, LightbeamOperator
 from edu_edfi_airflow.providers.snowflake.transfers.s3_to_snowflake import S3ToSnowflakeOperator
 
-from log_util import capture_log_stream
+from edu_edfi_airflow.callables.log_util import capture_log_stream
 
 class EarthbeamDAG:
     """

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -867,7 +867,15 @@ class EarthbeamDAG:
                     output_dir=em_output_dir,
                     state_file=em_state_file,
                     snowflake_read_conn_id=snowflake_read_conn_id,
+
+                    # vars added just for the logging to snowflake... TODO must be a better way
                     snowflake_log_conn_id=snowflake_conn_id,
+                    logging_table=logging_table,
+                    tenant_code=tenant_code,
+                    api_year=api_year,
+                    grain_update=grain_update,
+                    run_type=self.run_type,
+
                     results_file=em_results_file,
                     **self.inject_parameters_into_kwargs(env_mapping, earthmover_kwargs),
                     dag=self.dag

--- a/edu_edfi_airflow/dags/earthbeam_dag.py
+++ b/edu_edfi_airflow/dags/earthbeam_dag.py
@@ -356,7 +356,7 @@ class EarthbeamDAG:
                 if logging_table:
                     # Wrap the callable with log capturing
                     wrapped_callable = capture_logs_to_snowflake(
-                        python_callable,
+                        run_callable=python_callable,
                         snowflake_conn_id=snowflake_conn_id,
                         logging_table=logging_table,
                         tenant_code=tenant_code,
@@ -498,7 +498,7 @@ class EarthbeamDAG:
                 if logging_table:
                     # Wrap the callable with log capturing
                     wrapped_callable = capture_logs_to_snowflake(
-                        python_callable,
+                        run_callable=python_callable,
                         snowflake_conn_id=snowflake_conn_id,
                         logging_table=logging_table,
                         tenant_code=tenant_code,

--- a/edu_edfi_airflow/providers/earthbeam/operators.py
+++ b/edu_edfi_airflow/providers/earthbeam/operators.py
@@ -136,7 +136,7 @@ class EarthmoverOperator(BashOperator):
             run_type=self.run_type,
         )
 
-        return wrapped_execute(context)
+        return wrapped_execute(context=context)
 
 
 

--- a/edu_edfi_airflow/providers/earthbeam/operators.py
+++ b/edu_edfi_airflow/providers/earthbeam/operators.py
@@ -114,8 +114,7 @@ class EarthmoverOperator(BashOperator):
         return capture_logs_to_snowflake(
             run_callable=lambda: super().execute(context),
             snowflake_conn_id=self.snowflake_log_conn_id,
-            logging_table=env.get("LOGGING_TABLE"),
-            log_data=structured_logs,
+            logging_table=self.env.get("LOGGING_TABLE"),
             tenant_code=self.env.get("TENANT_CODE"),
             api_year=self.env.get("API_YEAR"),
             run_type=self.env.get("RUN_TYPE"),

--- a/edu_edfi_airflow/providers/earthbeam/operators.py
+++ b/edu_edfi_airflow/providers/earthbeam/operators.py
@@ -7,7 +7,6 @@ from airflow.models import Connection
 from airflow.operators.bash import BashOperator
 
 from edu_edfi_airflow.callables import airflow_util
-from edu_edfi_airflow.callables.log_util import capture_logs_to_snowflake
 
 
 class EarthmoverOperator(BashOperator):
@@ -28,14 +27,6 @@ class EarthmoverOperator(BashOperator):
         results_file: Optional[str] = None,
         snowflake_read_conn_id: Optional[str] = None,
 
-        # Logging args
-        snowflake_log_conn_id: Optional[str] = None,
-        logging_table: Optional[str] = None,
-        tenant_code: Optional[str] = None,
-        api_year: Optional[str] = None,
-        grain_update: Optional[str] = None,
-        run_type: Optional[str] = None,
-
         force          : bool = False,
         skip_hashing   : bool = False,
         show_graph     : bool = False,
@@ -47,13 +38,6 @@ class EarthmoverOperator(BashOperator):
         self.output_dir = output_dir
         self.state_file = state_file
         self.snowflake_read_conn_id = snowflake_read_conn_id
-
-        self.snowflake_log_conn_id = snowflake_log_conn_id
-        self.logging_table = logging_table
-        self.tenant_code = tenant_code
-        self.api_year = api_year
-        self.grain_update = grain_update
-        self.run_type = run_type
 
         ### Building the Earthmover CLI command
         self.arguments = {}
@@ -120,23 +104,12 @@ class EarthmoverOperator(BashOperator):
         
         self.bash_command += " ".join(cli_arguments)
         logging.info(f"Complete Earthmover CLI command: {self.bash_command}")
-        logging.info(f"Snowflake Log Conn ID: {self.snowflake_log_conn_id}")
-        logging.info(f"Snowflake Logging Table: {self.logging_table}")
 
         # Create state_dir if not already defined in filespace
         os.makedirs(os.path.dirname(self.state_file), exist_ok=True)
 
-        wrapped_execute = capture_logs_to_snowflake(
-            super().execute,
-            snowflake_conn_id=self.snowflake_log_conn_id,
-            logging_table=self.logging_table,
-            tenant_code=self.tenant_code,
-            api_year=self.api_year,
-            grain_update=self.grain_update,
-            run_type=self.run_type,
-        )
-
-        return wrapped_execute(context=context)
+        super().execute(context)
+        return self.output_dir
 
 
 

--- a/edu_edfi_airflow/providers/earthbeam/operators.py
+++ b/edu_edfi_airflow/providers/earthbeam/operators.py
@@ -111,16 +111,17 @@ class EarthmoverOperator(BashOperator):
         # Create state_dir if not already defined in filespace
         os.makedirs(os.path.dirname(self.state_file), exist_ok=True)
 
-        return capture_logs_to_snowflake(
-            run_callable=lambda: super().execute(context),
-            snowflake_conn_id=self.snowflake_log_conn_id,
-            logging_table=self.env.get("LOGGING_TABLE"),
-            tenant_code=self.env.get("TENANT_CODE"),
-            api_year=self.env.get("API_YEAR"),
-            run_type=self.env.get("RUN_TYPE"),
-            grain_update=self.env.get("GRAIN_UPDATE", None),
-            **kwargs
+        wrapped_execute = capture_logs_to_snowflake(
+            super().execute,
+            snowflake_conn_id=self.snowflake_read_conn_id,
+            logging_table=self.env.get("logging_table"),
+            tenant_code=self.env.get("tenant_code"),
+            api_year=self.env.get("api_year"),
+            grain_update=self.env.get("grain_update"),
+            run_type=self.env.get("run_type"),
         )
+
+        return wrapped_execute(context)
 
 
 

--- a/edu_edfi_airflow/providers/earthbeam/operators.py
+++ b/edu_edfi_airflow/providers/earthbeam/operators.py
@@ -27,7 +27,14 @@ class EarthmoverOperator(BashOperator):
         parameters : Optional[Union[str, dict]] = None,
         results_file: Optional[str] = None,
         snowflake_read_conn_id: Optional[str] = None,
+
+        # Logging args
         snowflake_log_conn_id: Optional[str] = None,
+        logging_table: Optional[str] = None,
+        tenant_code: Optional[str] = None,
+        api_year: Optional[str] = None,
+        grain_update: Optional[str] = None,
+        run_type: Optional[str] = None,
 
         force          : bool = False,
         skip_hashing   : bool = False,
@@ -40,7 +47,13 @@ class EarthmoverOperator(BashOperator):
         self.output_dir = output_dir
         self.state_file = state_file
         self.snowflake_read_conn_id = snowflake_read_conn_id
+
         self.snowflake_log_conn_id = snowflake_log_conn_id
+        self.logging_table = logging_table
+        self.tenant_code = tenant_code
+        self.api_year = api_year
+        self.grain_update = grain_update
+        self.run_type = run_type
 
         ### Building the Earthmover CLI command
         self.arguments = {}
@@ -107,18 +120,20 @@ class EarthmoverOperator(BashOperator):
         
         self.bash_command += " ".join(cli_arguments)
         logging.info(f"Complete Earthmover CLI command: {self.bash_command}")
+        logging.info(f"Snowflake Log Conn ID: {self.snowflake_log_conn_id}")
+        logging.info(f"Snowflake Logging Table: {self.logging_table}")
 
         # Create state_dir if not already defined in filespace
         os.makedirs(os.path.dirname(self.state_file), exist_ok=True)
 
         wrapped_execute = capture_logs_to_snowflake(
             super().execute,
-            snowflake_conn_id=self.snowflake_read_conn_id,
-            logging_table=self.env.get("logging_table"),
-            tenant_code=self.env.get("tenant_code"),
-            api_year=self.env.get("api_year"),
-            grain_update=self.env.get("grain_update"),
-            run_type=self.env.get("run_type"),
+            snowflake_conn_id=self.snowflake_log_conn_id,
+            logging_table=self.logging_table,
+            tenant_code=self.tenant_code,
+            api_year=self.api_year,
+            grain_update=self.grain_update,
+            run_type=self.run_type,
         )
 
         return wrapped_execute(context)

--- a/edu_edfi_airflow/providers/earthbeam/operators.py
+++ b/edu_edfi_airflow/providers/earthbeam/operators.py
@@ -122,8 +122,7 @@ class EarthmoverOperator(BashOperator):
                 api_year=self.env.get("API_YEAR", "unknown"),
                 run_type=self.env.get("RUN_TYPE", "earthmover"),
                 grain_update=self.env.get("GRAIN_UPDATE", None),
-                run_date=context["ds"],
-                run_timestamp=context["ts"]
+                **kwargs
             )
 
         return self.output_dir


### PR DESCRIPTION
Expands previous functionality for logging errors from airflow pre-process task to snowflake, to include errors that occur during earthmover task run. I had to make some considerable changes, because previous code worked smoothly with base pythonOperators ,and earthmover isn't that, so I moved code into the `execute`.


This involves a lot of code that is firmly outside my expertise, so hoping for some careful review on this. Some things to note before review:
- I moved logging functions out of earthbeam_dags.py and into log_util.py
  - This way they can easily be used by earthmover operators.py
- There's a lot of nested function calls. I assume there's a cleaner way to do all this, please advise :) 
- I had to send a whole bunch of args just for logging into earthmover operator -- can you help me find a better way?