### PR TITLE
Bugfix/delete handling

### DIFF
--- a/edu_edfi_airflow/dags/edfi_resource_dag.py
+++ b/edu_edfi_airflow/dags/edfi_resource_dag.py
@@ -448,6 +448,7 @@ class EdFiResourceDAG:
                 'endpoints': endpoints,
                 'get_deletes': get_deletes,
                 'get_key_changes': get_key_changes,
+                'has_key_changes': self.get_key_changes # Indicates whether to add keyChanges records on full refresh, since this column is not yet required
             },
             provide_context=True,
             dag=self.dag,

--- a/edu_edfi_airflow/dags/edfi_resource_dag.py
+++ b/edu_edfi_airflow/dags/edfi_resource_dag.py
@@ -576,6 +576,7 @@ class EdFiResourceDAG:
                 snowflake_conn_id=self.snowflake_conn_id,
                 s3_destination_key=self.xcom_pull_template_map_idx(pull_operators_list, 1),
                 full_refresh=(get_deletes and self.pull_all_deletes),
+                enabled_endpoints=enabled_endpoints,
 
                 trigger_rule='all_done',
                 dag=self.dag
@@ -703,6 +704,7 @@ class EdFiResourceDAG:
                 snowflake_conn_id=self.snowflake_conn_id,
                 s3_destination_key=self.xcom_pull_template_map_idx(pull_edfi_to_s3, 1),
                 full_refresh=(get_deletes and self.pull_all_deletes),
+                enabled_endpoints=enabled_endpoints,
 
                 trigger_rule='all_done',
                 dag=self.dag
@@ -831,6 +833,7 @@ class EdFiResourceDAG:
                 snowflake_conn_id=self.snowflake_conn_id,
                 s3_destination_key=self.xcom_pull_template_map_idx(pull_edfi_to_s3, 1),
                 full_refresh=(get_deletes and self.pull_all_deletes),
+                enabled_endpoints=enabled_endpoints,
 
                 trigger_rule='none_skipped',  # Different trigger rule than default.
                 dag=self.dag

--- a/edu_edfi_airflow/dags/edfi_resource_dag.py
+++ b/edu_edfi_airflow/dags/edfi_resource_dag.py
@@ -576,7 +576,6 @@ class EdFiResourceDAG:
                 snowflake_conn_id=self.snowflake_conn_id,
                 s3_destination_key=self.xcom_pull_template_map_idx(pull_operators_list, 1),
                 full_refresh=(get_deletes and self.pull_all_deletes),
-                enabled_endpoints=enabled_endpoints,
 
                 trigger_rule='all_done',
                 dag=self.dag
@@ -704,7 +703,6 @@ class EdFiResourceDAG:
                 snowflake_conn_id=self.snowflake_conn_id,
                 s3_destination_key=self.xcom_pull_template_map_idx(pull_edfi_to_s3, 1),
                 full_refresh=(get_deletes and self.pull_all_deletes),
-                enabled_endpoints=enabled_endpoints,
 
                 trigger_rule='all_done',
                 dag=self.dag
@@ -833,7 +831,6 @@ class EdFiResourceDAG:
                 snowflake_conn_id=self.snowflake_conn_id,
                 s3_destination_key=self.xcom_pull_template_map_idx(pull_edfi_to_s3, 1),
                 full_refresh=(get_deletes and self.pull_all_deletes),
-                enabled_endpoints=enabled_endpoints,
 
                 trigger_rule='none_skipped',  # Different trigger rule than default.
                 dag=self.dag

--- a/edu_edfi_airflow/providers/snowflake/transfers/s3_to_snowflake.py
+++ b/edu_edfi_airflow/providers/snowflake/transfers/s3_to_snowflake.py
@@ -171,6 +171,11 @@ class BulkS3ToSnowflakeOperator(S3ToSnowflakeOperator):
             if airflow_util.is_full_refresh(context) and isinstance(self.table_name, str):
                 logging.info("Deleting existing records due to full refresh...")
                 self.run_bulk_sql_queries(table=self.table_name, delete_all=True)
+                
+                if self.xcom_return:  # Maintain backwards-compatibility with original S3ToSnowflakeOperator
+                    return self.xcom_return
+                else:
+                    return []
             else:
                 raise AirflowSkipException("There are no endpoints to copy to Snowflake. Skipping task...")
 

--- a/edu_edfi_airflow/providers/snowflake/transfers/s3_to_snowflake.py
+++ b/edu_edfi_airflow/providers/snowflake/transfers/s3_to_snowflake.py
@@ -37,7 +37,6 @@ class S3ToSnowflakeOperator(BaseOperator):
         data_model_version: Optional[str] = None,
 
         full_refresh: bool = False,
-        enabled_endpoints: Optional[List[str]] = None,
         xcom_return: Optional[Any] = None,
         **kwargs
     ) -> None:
@@ -59,7 +58,6 @@ class S3ToSnowflakeOperator(BaseOperator):
         self.data_model_version = data_model_version
 
         self.full_refresh = full_refresh
-        self.enabled_endpoints = enabled_endpoints
         self.xcom_return = xcom_return
 
 
@@ -172,7 +170,7 @@ class BulkS3ToSnowflakeOperator(S3ToSnowflakeOperator):
             # For deletes and keyChanges, delete all records during a full refresh.
             if airflow_util.is_full_refresh(context) and isinstance(self.table_name, str):
                 logging.info("Deleting existing records due to full refresh...")
-                self.run_bulk_sql_queries(table=self.table_name, names=self.enabled_endpoints, delete_all=True)
+                self.run_bulk_sql_queries(table=self.table_name, names=airflow_util.get_config_endpoints(context), delete_all=True)
                 
                 if self.xcom_return:  # Maintain backwards-compatibility with original S3ToSnowflakeOperator
                     return self.xcom_return
@@ -241,7 +239,7 @@ class BulkS3ToSnowflakeOperator(S3ToSnowflakeOperator):
         else:
             return xcom_returns
 
-    def run_bulk_sql_queries(self, table: str, s3_dir: str = '', names: list[str] = [], delete_all: bool = False):
+    def run_bulk_sql_queries(self, table: str, s3_dir: str = '', names: List[str] = [], delete_all: bool = False):
         """
         Alternative delete and copy queries to be run when all data is sent to the same table in Snowflake.
         
@@ -258,13 +256,16 @@ class BulkS3ToSnowflakeOperator(S3ToSnowflakeOperator):
         ### If delete_all is True, delete all records for the tenant and api_year.
         # This is used to clear deletes and keyChanges during a full refresh.
         if delete_all:
-            names_string = "', '".join(names)
+            if len(names):
+                names_string = f"AND name in ('{"', '".join(names)}')"
+            else:
+                names_string = ''
 
             qry_delete = f"""
                 DELETE FROM {database}.{schema}.{table}
                 WHERE tenant_code = '{self.tenant_code}'
                 AND api_year = '{self.api_year}'
-                AND name in ('{names_string}')
+                {names_string}
             """
             snowflake_hook.run(sql=qry_delete)
 


### PR DESCRIPTION
This PR addresses two bugs related to the behavior of deletes and keyChanges during full refreshes. 
1. Updates the `BulkS3ToSnowflakeOperator` to trigger deletion of all records for the tenant/year from the `_deletes` and `_key_changes` tables during a full refresh. Currently this task skips, so records are never deleted. This involved rearranging the `run_bulk_sql_queries` function because deletes and keyChanges are either copied or deleted, but never both in the same run.
2. Updates the `update_change_versions` function to insert rows for deletes and keyChanges (if used) during a full refresh so that they are not pulled from 0 on the next run. This happens in the resources taskgroup to avoid the need to awkwardly pass the list of pulled endpoints to the other taskgroups. 

This has been tested in CA and confirmed that deletes are cleared during full refreshes and not pulled from 0 on the next run. 