### PR TITLE
Feature/run total counts taskgroup earlier

### DIFF
--- a/edu_edfi_airflow/dags/edfi_resource_dag.py
+++ b/edu_edfi_airflow/dags/edfi_resource_dag.py
@@ -331,7 +331,7 @@ class EdFiResourceDAG:
         )
 
         # Chain tasks and taskgroups into the DAG; chain sentinel after all task groups.
-        airflow_util.chain_tasks(cv_task_group, edfi_task_groups, total_counts_taskgroup, dbt_var_increment_operator)
+        airflow_util.chain_tasks(cv_task_group, total_counts_taskgroup, edfi_task_groups, dbt_var_increment_operator)
         airflow_util.chain_tasks(edfi_task_groups, dag_state_sentinel)
 
 


### PR DESCRIPTION
Switches the order of the task groups to run the Total Counts tasks earlier. This minimizes the time between the pull of the latest change version and the pull of total counts, during which any updates would inaccurately reduce the total count.

Confirmed that this correctly alters the DAG dependencies.