### PR TITLE
fix cv handling

### DIFF
--- a/edu_edfi_airflow/callables/change_version.py
+++ b/edu_edfi_airflow/callables/change_version.py
@@ -110,7 +110,7 @@ def get_previous_change_versions(
     elif get_key_changes:
         filter_clause = "is_key_changes"
     else:
-        filter_clause = "TRUE"
+        filter_clause = "not is_deletes and not is_key_changes"
 
     qry_prior_max = f"""
         select name, max(max_version) as max_version


### PR DESCRIPTION
When pulling prior max CVs on a resource, we need to exclude deletes and key_changes, not take the max across all records