### PR TITLE
Maintain python backwards compatibility

### DIFF
--- a/edu_edfi_airflow/providers/snowflake/transfers/s3_to_snowflake.py
+++ b/edu_edfi_airflow/providers/snowflake/transfers/s3_to_snowflake.py
@@ -257,7 +257,7 @@ class BulkS3ToSnowflakeOperator(S3ToSnowflakeOperator):
         # This is used to clear deletes and keyChanges during a full refresh.
         if delete_all:
             if len(names):
-                names_string = f"AND name in ('{"', '".join(names)}')"
+                names_string = f"""AND name in ('{"', '".join(names)}')"""
             else:
                 names_string = ''
 


### PR DESCRIPTION
Use f-string syntax with support in older python versions. Confirmed working in 3.11.

Closes #114