### PR TITLE
Feature/storage interfaces  failed total counts

### DIFF
--- a/edu_edfi_airflow/callables/change_version.py
+++ b/edu_edfi_airflow/callables/change_version.py
@@ -2,7 +2,7 @@ import logging
 
 from typing import Dict, List, Tuple, Optional
 
-from airflow.exceptions import AirflowFailException, AirflowSkipException
+from airflow.exceptions import AirflowSkipException
 
 from edu_edfi_airflow.callables import airflow_util
 from edu_edfi_airflow.interfaces.database import DatabaseInterface
@@ -227,7 +227,7 @@ def get_previous_change_versions_with_deltas(
 
     # But also raise an error if at least one endpoint failed!
     if failed_endpoints:
-        raise AirflowFailException(
+        raise ValueError(
             f"Failed getting delta row count for one or more endpoints: {failed_endpoints}"
         ) from None  # Disable stacktrace
     

--- a/edu_edfi_airflow/callables/change_version.py
+++ b/edu_edfi_airflow/callables/change_version.py
@@ -2,7 +2,7 @@ import logging
 
 from typing import Dict, List, Tuple, Optional
 
-from airflow.exceptions import AirflowSkipException
+from airflow.exceptions import AirflowFailException, AirflowSkipException
 
 from edu_edfi_airflow.callables import airflow_util
 from edu_edfi_airflow.interfaces.database import DatabaseInterface
@@ -227,9 +227,7 @@ def get_previous_change_versions_with_deltas(
 
     # But also raise an error if at least one endpoint failed!
     if failed_endpoints:
-        raise ValueError(
-            f"Failed getting delta row count for one or more endpoints: {failed_endpoints}"
-        ) from None  # Disable stacktrace
+        raise AirflowFailException(f"Failed getting delta row count for one or more endpoints: {failed_endpoints}")
     
     return delta_endpoints
 

--- a/edu_edfi_airflow/callables/change_version.py
+++ b/edu_edfi_airflow/callables/change_version.py
@@ -227,7 +227,9 @@ def get_previous_change_versions_with_deltas(
 
     # But also raise an error if at least one endpoint failed!
     if failed_endpoints:
-        raise AirflowFailException(f"Failed getting delta row count for one or more endpoints: {failed_endpoints}")
+        raise AirflowFailException(
+            f"Failed getting delta row count for one or more endpoints: {failed_endpoints}"
+        ) from None  # Disable stacktrace
     
     return delta_endpoints
 

--- a/edu_edfi_airflow/dags/edfi_resource_dag.py
+++ b/edu_edfi_airflow/dags/edfi_resource_dag.py
@@ -751,7 +751,7 @@ class EdFiResourceDAG:
             # If change versions are enabled, dynamically expand the output of the CV operator task into the Ed-Fi bulk operator.
             if self.use_change_version:
                 get_cv_operator = self.build_change_version_get_operator(
-                    task_id=f"get_last_change_versions",
+                    task_id=f"get_last_change_versions_from_database",
                     endpoints=[(self.endpoint_configs[endpoint]['namespace'], endpoint) for endpoint in endpoints],
                     get_deletes=get_deletes,
                     get_key_changes=get_key_changes,

--- a/edu_edfi_airflow/dags/edfi_resource_dag.py
+++ b/edu_edfi_airflow/dags/edfi_resource_dag.py
@@ -392,7 +392,7 @@ class EdFiResourceDAG:
 
         :return:
         """
-        get_cv_operator = PythonOperator(
+        return PythonOperator(
             task_id=task_id,
             python_callable=change_version.get_previous_change_versions_with_deltas if get_with_deltas else change_version.get_previous_change_versions,
             op_kwargs={


### PR DESCRIPTION
The `get_last_change_versions_from_snowflake__failed_total_counts` operator only existed to resolve a bug in an earlier version of Airflow where operators with a `none_skipped` trigger rule would not run when an upstream task fails. This is resolved in Airflow 2.9.3, so we can remove this operator.

Even when the `get_last_change_versions_from_database` task fails due to one or more endpoints being inaccessible, the downstream ingestions and copies still run.

<img width="433" height="99" alt="Screenshot 2025-12-10 121815" src="https://github.com/user-attachments/assets/f96716f9-b86e-4c5f-92d2-fb5a128d2696" />
 