### PR TITLE
Add is_sideloaded column to COPY INTO statements, functions

### DIFF
--- a/edu_edfi_airflow/interfaces/database.py
+++ b/edu_edfi_airflow/interfaces/database.py
@@ -155,7 +155,7 @@ class SnowflakeDatabaseInterface(DatabaseInterface):
 
         qry = f"""
             COPY INTO {self.database}.{self.schema}.{table}
-                (tenant_code, api_year, pull_date, pull_timestamp, file_row_number, filename, name, ods_version, data_model_version, v)
+                (tenant_code, api_year, pull_date, pull_timestamp, file_row_number, filename, name, ods_version, data_model_version, is_sideloaded, v)
             FROM (
                 SELECT
                     '{tenant_code}' AS tenant_code,
@@ -191,7 +191,7 @@ class SnowflakeDatabaseInterface(DatabaseInterface):
 
         qry = f"""
             COPY INTO {self.database}.{self.schema}.{table}
-                (tenant_code, api_year, pull_date, pull_timestamp, file_row_number, filename, name, ods_version, data_model_version, v)
+                (tenant_code, api_year, pull_date, pull_timestamp, file_row_number, filename, name, ods_version, data_model_version, is_sideloaded, v)
             FROM (
                 SELECT
                     '{tenant_code}' AS tenant_code,

--- a/edu_edfi_airflow/interfaces/database.py
+++ b/edu_edfi_airflow/interfaces/database.py
@@ -139,13 +139,15 @@ class SnowflakeDatabaseInterface(DatabaseInterface):
             WHERE tenant_code = '{tenant_code}'
             AND api_year = '{api_year}'
             AND name in ('{names_repr}')
+            AND not is_sideloaded
         """
         self.sql.append(qry)
         return qry
     
     def copy_into_raw(self,
         tenant_code: str, api_year: str, name: str, table: str,
-        ods_version: int, data_model_version: str, storage_path: str
+        ods_version: int, data_model_version: str, storage_path: str,
+        is_sideloaded: bool = False
     ) -> str:
         # Brackets in regex conflict with string formatting.
         date_regex = "\\\\d{8}"
@@ -165,6 +167,7 @@ class SnowflakeDatabaseInterface(DatabaseInterface):
                     '{name}' AS name,
                     '{ods_version}' AS ods_version,
                     '{data_model_version}' AS data_model_version,
+                    {is_sideloaded} AS is_sideloaded,
                     t.$1 AS v
                 FROM '@{self.database}.util.airflow_stage/{storage_path}'
                 (file_format => 'json_default') t
@@ -176,7 +179,8 @@ class SnowflakeDatabaseInterface(DatabaseInterface):
 
     def bulk_copy_into_raw(self,
         tenant_code: str, api_year: str, name: List[str], table: str,
-        ods_version: int, data_model_version: str, storage_path: str
+        ods_version: int, data_model_version: str, storage_path: str,
+        is_sideloaded: bool = False
     ) -> str:
         # Always use the directory for bulk copies into Snowflake
         storage_dir = os.path.dirname(storage_path)
@@ -199,6 +203,7 @@ class SnowflakeDatabaseInterface(DatabaseInterface):
                     REGEXP_SUBSTR(filename, '.+/(\\\\w+).jsonl?', 1, 1, 'c', 1) AS name,
                     '{ods_version}' AS ods_version,
                     '{data_model_version}' AS data_model_version,
+                    {is_sideloaded} AS is_sideloaded,
                     t.$1 AS v
                 FROM '@{self.database}.util.airflow_stage/{storage_dir}'
                 (file_format => 'json_default') t
@@ -279,13 +284,15 @@ class DatabricksDatabaseInterface(DatabaseInterface):
             WHERE tenant_code = '{tenant_code}'
             AND api_year = '{api_year}'
             AND name in ('{names_repr}')
+            AND not is_sideloaded
         """
         self.sql.append(qry)
         return qry
     
     def copy_into_raw(self,
         tenant_code: str, api_year: str, name: str, table: str,
-        ods_version: int, data_model_version: str, storage_path: str
+        ods_version: int, data_model_version: str, storage_path: str,
+        is_sideloaded: bool = False
     ) -> str:
         qry = f"""
             COPY INTO {self.database}.{self.schema}.{table}
@@ -301,6 +308,7 @@ class DatabricksDatabaseInterface(DatabaseInterface):
                     '{name}' AS name,
                     '{ods_version}' AS ods_version,
                     '{data_model_version}' AS data_model_version,
+                    {is_sideloaded} AS is_sideloaded,
                     v
                 FROM '{storage_path}'
             )

--- a/edu_edfi_airflow/providers/snowflake/transfers/s3_to_snowflake.py
+++ b/edu_edfi_airflow/providers/snowflake/transfers/s3_to_snowflake.py
@@ -110,7 +110,7 @@ class S3ToSnowflakeOperator(BaseOperator):
                 f"Arguments `ods_version` and `data_model_version` could not be retrieved and must be provided."
             )
 
-    def run_sql_queries(self, name: str, table: str, s3_key: str, full_refresh: bool = False):
+    def run_sql_queries(self, name: str, table: str, s3_key: str, full_refresh: bool = False, is_sideloaded: bool = False):
         """
 
         """
@@ -137,6 +137,7 @@ class S3ToSnowflakeOperator(BaseOperator):
                     '{name}' AS name,
                     '{self.ods_version}' AS ods_version,
                     '{self.data_model_version}' AS data_model_version,
+                    {is_sideloaded} AS is_sideloaded,
                     t.$1 AS v
                 FROM '@{database}.util.airflow_stage/{s3_key}'
                 (file_format => 'json_default') t
@@ -242,7 +243,7 @@ class BulkS3ToSnowflakeOperator(S3ToSnowflakeOperator):
         else:
             return xcom_returns
 
-    def run_bulk_sql_queries(self, table: str, s3_dir: str = '', names: List[str] = [], delete_all: bool = False):
+    def run_bulk_sql_queries(self, table: str, s3_dir: str = '', names: List[str] = [], delete_all: bool = False, is_sideloaded: bool = False):
         """
         Alternative delete and copy queries to be run when all data is sent to the same table in Snowflake.
         
@@ -292,6 +293,7 @@ class BulkS3ToSnowflakeOperator(S3ToSnowflakeOperator):
                         REGEXP_SUBSTR(filename, '.+/(\\\\w+).jsonl?', 1, 1, 'c', 1) AS name,
                         '{self.ods_version}' AS ods_version,
                         '{self.data_model_version}' AS data_model_version,
+                        {is_sideloaded} AS is_sideloaded,
                         t.$1 AS v
                     FROM '@{database}.util.airflow_stage/{s3_dir}'
                     (file_format => 'json_default') t

--- a/edu_edfi_airflow/providers/snowflake/transfers/s3_to_snowflake.py
+++ b/edu_edfi_airflow/providers/snowflake/transfers/s3_to_snowflake.py
@@ -125,7 +125,7 @@ class S3ToSnowflakeOperator(BaseOperator):
 
         qry_copy_into = f"""
             COPY INTO {database}.{schema}.{table}
-                (tenant_code, api_year, pull_date, pull_timestamp, file_row_number, filename, name, ods_version, data_model_version, v)
+                (tenant_code, api_year, pull_date, pull_timestamp, file_row_number, filename, name, ods_version, data_model_version, is_sideloaded, v)
             FROM (
                 SELECT
                     '{self.tenant_code}' AS tenant_code,
@@ -281,7 +281,7 @@ class BulkS3ToSnowflakeOperator(S3ToSnowflakeOperator):
 
             qry_copy_into = f"""
                 COPY INTO {database}.{schema}.{table}
-                    (tenant_code, api_year, pull_date, pull_timestamp, file_row_number, filename, name, ods_version, data_model_version, v)
+                    (tenant_code, api_year, pull_date, pull_timestamp, file_row_number, filename, name, ods_version, data_model_version, is_sideloaded, v)
                 FROM (
                     SELECT
                         '{self.tenant_code}' AS tenant_code,

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = (HERE / "README.md").read_text()
 
 setuptools.setup(
       name='edu_edfi_airflow',
-      version='0.6.0',
+      version='0.7.0',
 
       description='EDU Airflow tools for Ed-Fi',
       license_files=['LICENSE.md'],


### PR DESCRIPTION
Jira: https://edanalytics.atlassian.net/browse/STADIUM-315

This PR introduces a new column, `is_sideloaded` to `COPY INTO` statements and functions. It is the companion PR to the recent implementation of sideloading in the Runway Python Client, https://github.com/[edanalytics/runway_python_client](https://github.com/edanalytics/runway_python_client).

`is_sideloaded` will be `False` by default, and only sideloading DAGs should set it to `True`. Full-refresh's will ignore sideloaded rows.

The following script was run to update all RAW tables in the WDL and MOREnet warehouses:

```sql
DECLARE
  c1 CURSOR FOR
    SELECT table_catalog || '.' || table_schema || '.' || table_name AS fqn
    FROM RAW.INFORMATION_SCHEMA.TABLES
    WHERE table_schema = 'EDFI3' AND table_type = 'BASE TABLE';
BEGIN
  FOR rec IN c1 DO
    EXECUTE IMMEDIATE 'ALTER TABLE ' || rec.fqn || ' ADD COLUMN IF NOT EXISTS IS_SIDELOADED BOOLEAN DEFAULT FALSE';
  END FOR;
END;
```

See their PRs for more information about those changes:
* https://github.com/edanalytics/stadium_wdl/pull/118
* https://github.com/edanalytics/stadium_morenet/pull/56
